### PR TITLE
Fix regexp address benchmarks.

### DIFF
--- a/edit/addr.go
+++ b/edit/addr.go
@@ -285,6 +285,9 @@ func (l lineAddr) rev(from int64, ed *Editor) (Range, error) {
 	return a, nil
 }
 
+// ErrNoMatch is returned when a regular expression address fails to match.
+var ErrNoMatch = errors.New("no match")
+
 type reAddr struct {
 	rev bool
 	re  string
@@ -338,7 +341,7 @@ func (r reAddr) rangeFrom(from int64, ed *Editor) (a Range, err error) {
 	defer runes.RecoverRuneReadError(&err)
 	match := re.Match(rs, from)
 	if match == nil {
-		return a, errors.New("no match")
+		return a, ErrNoMatch
 	}
 	a = Range{From: match[0][0], To: match[0][1]}
 	if r.rev {

--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -57,15 +57,20 @@ func benchmarkRegexp(b *testing.B, re string, n int) {
 	b.ResetTimer()
 	b.SetBytes(int64(n))
 	for i := 0; i < b.N; i++ {
-		Regexp(re).rangeFrom(0, ed)
+		switch _, err := Regexp(re).rangeFrom(0, ed); {
+		case err == nil:
+			panic("unexpected match")
+		case err != ErrNoMatch:
+			panic(err)
+		}
 	}
 }
 
 const (
-	easy0  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
-	easy1  = "A[AB]B[BC]C[CD]D[DE]E[EF]F[FG]G[GH]H[HI]I[IJ]J$"
-	medium = "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
-	hard   = "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	easy0  = "/ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	easy1  = "/A[AB]B[BC]C[CD]D[DE]E[EF]F[FG]G[GH]H[HI]I[IJ]J$"
+	medium = "/[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	hard   = "/[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
 )
 
 func BenchmarkRegexpEasy0x32(b *testing.B)  { benchmarkRegexp(b, easy0, 32<<0) }


### PR DESCRIPTION
edit.Regexp requires the regular experssions to be delimited.
The benchmark expressions didn't begin with a delimiter.
However, since we never checked the error,
we missed that it was failing for the medium and hard cases.
Now we return ErrNoMatch if the expression fails to match.
The benchmark ensures that this is the result
(since it never expects to match).

Now the benchmarks make sense:
BenchmarkRegexpEasy0x32	   10000	    124121 ns/op	   0.26 MB/s
BenchmarkRegexpEasy0x1K	   10000	    140324 ns/op	   7.30 MB/s
BenchmarkRegexpEasy1x32	   20000	     98823 ns/op	   0.32 MB/s
BenchmarkRegexpEasy1x1K	   10000	    113419 ns/op	   9.03 MB/s
BenchmarkRegexpMediumx32	   10000	    130109 ns/op	   0.01 MB/s
BenchmarkRegexpMediumx1K	   10000	    157064 ns/op	   6.52 MB/s
BenchmarkRegexpHardx32	   10000	    156377 ns/op	   0.20 MB/s
BenchmarkRegexpHardx1K	    3000	    516775 ns/op	   1.98 MB/s