### PR TITLE
Implement mark addresses.

### DIFF
--- a/edit/addr.go
+++ b/edit/addr.go
@@ -535,7 +535,7 @@ loop:
 			break loop
 		}
 		n += m
-		if a != nil {
+		if a != nil || err != nil {
 			return a, n, err
 		}
 		rs = rs[n:]
@@ -565,7 +565,6 @@ func parseLineAddr(rs []rune) (SimpleAddress, int, error) {
 	}
 	var n int
 	for n = 1; n < len(rs) && strings.ContainsRune(digits, rs[n]); n++ {
-		n++
 	}
 	l, err := strconv.Atoi(string(rs[:n]))
 	return Line(l), n, err

--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -27,7 +27,7 @@ func makeEditor(n int) (*Editor, int) {
 		}
 	}
 	ed := NewBuffer().NewEditor()
-	if err := ed.Insert(All(), rs); err != nil {
+	if err := ed.Insert(All, rs); err != nil {
 		panic(err)
 	}
 	return ed, lines

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -66,11 +66,11 @@ func (test changeTest) run(f func(*Editor, Address, []rune) error, name string, 
 		t.Errorf("%v: %s(%v, %v)=%v, want nil", test, name, test.addr, test.add, err)
 		return
 	}
-	if ed.dot != test.dot {
-		t.Errorf("%v: dot=%v, want %v\n", test, ed.dot, test.dot)
+	if ed.marks['.'] != test.dot {
+		t.Errorf("%v: dot=%v, want %v\n", test, ed.marks['.'], test.dot)
 		return
 	}
-	rs, err := ed.Read(All())
+	rs, err := ed.Read(All)
 	if s := string(rs); s != test.want || err != nil {
 		t.Errorf("%v: string=%v, want %v\n",
 			test, strconv.Quote(s), strconv.Quote(test.want))
@@ -107,11 +107,11 @@ func TestEditorDelete(t *testing.T) {
 			t.Errorf("%v: Delete(%v)=%v, want nil", test, test.addr, err)
 			continue
 		}
-		if ed.dot != test.dot {
-			t.Errorf("%v: dot=%v, want %v\n", test, ed.dot, test.dot)
+		if ed.marks['.'] != test.dot {
+			t.Errorf("%v: dot=%v, want %v\n", test, ed.marks['.'], test.dot)
 			continue
 		}
-		rs, err := ed.Read(All())
+		rs, err := ed.Read(All)
 		if s := string(rs); s != test.want || err != nil {
 			t.Errorf("%v: string=%v, want %v\n",
 				test, strconv.Quote(s), strconv.Quote(test.want))

--- a/gok.sh
+++ b/gok.sh
@@ -23,6 +23,14 @@ echo Testing
 go test -test.timeout=1s ./... 2>&1 > $o || fail
 
 echo Linting
-golint .
+golint .\
+	| grep -v 'should omit type Address'\
+	| grep -v 'should omit type SimpleAddress'\
+	> $o 2>&1
+# Silly: diff the grepped golint output with empty.
+# If it's non-empty, error, otherwise succeed.
+e=$(tempfile)
+touch $e
+diff $o $e > /dev/null || { rm $e; fail; }
 
-rm $o
+rm $o $e


### PR DESCRIPTION
To remove some special cases, dot is just a mark named '.'.
But you cannot create a mark named '.', so it can never be accidentally overridden.

Also, dots and marks can never be out-of-range.
Instead of returning an error if this happens, panic.

Also also, change Dot, End, and All from functions to variables.
Upside: removes noisy parentheses in addresses.
Downside: they could be accidentally re-assigned to junk.
But the downside never happens in practice.
Consider ErrWhatever variables.
They could be reassigned too.
It just never comes up.