### PR TITLE
Clarify the comment on edit.Regexp.

### DIFF
--- a/edit/addr.go
+++ b/edit/addr.go
@@ -381,7 +381,7 @@ type reAddr struct {
 	re  string
 }
 
-// Regexp returns a regular expression address.
+// Regexp returns an address identifying the next match of a regular expression.
 // The regular expression must be a delimited regular expression
 // using the syntax of the re1 package:
 // http://godoc.org/github.com/eaburns/T/re1.


### PR DESCRIPTION
It use to say that it returned a regular expression address without explaining what that is.
Now it explains that it returns an address identifying the next match.