### PR TITLE
Change re1.Runes.Rune to return an error.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -42,7 +42,7 @@ func (b *Buffer) size() int64 { return b.runes.Size() }
 // Returns the ith rune in the buffer.
 //
 // The caller must hold b.lock.
-func (b *Buffer) rune(i int64) rune { return b.runes.Rune(i) }
+func (b *Buffer) rune(i int64) (rune, error) { return b.runes.Rune(i) }
 
 // Change changes the runes in the range.
 //

--- a/re1/bench_test.go
+++ b/re1/bench_test.go
@@ -39,7 +39,7 @@ func benchmark(b *testing.B, re string, n int) {
 	b.ResetTimer()
 	b.SetBytes(int64(n))
 	for i := 0; i < b.N; i++ {
-		if r.Match(rs, 0) != nil {
+		if ms, err := r.Match(rs, 0); err != nil || ms != nil {
 			b.Fatal("match!")
 		}
 	}

--- a/runes/runes_test.go
+++ b/runes/runes_test.go
@@ -16,8 +16,8 @@ func TestRunesRune(t *testing.T) {
 		t.Fatalf(`b.Insert("%s", 0)=%v, want nil`, string(rs), err)
 	}
 	for i, want := range rs {
-		if got := b.Rune(int64(i)); got != want {
-			t.Errorf("b.Rune(%d)=%v, want %v", i, got, want)
+		if got, err := b.Rune(int64(i)); err != nil || got != want {
+			t.Errorf("b.Rune(%d)=%v,%v, want %v,nil", i, got, err, want)
 		}
 	}
 }


### PR DESCRIPTION
This is more verbose all over the place, but it obviates the need to panic IO errors.

Fixes #39.