### PR TITLE
Don't return an error from re1.Match.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -21,7 +21,12 @@ type Buffer struct {
 
 // NewBuffer returns a new, empty buffer.
 func NewBuffer() *Buffer {
-	return &Buffer{runes: runes.NewBuffer(blockSize)}
+	return newBufferRunes(runes.NewBuffer(blockSize))
+}
+
+// NewBufferRunes is like NewBuffer, but the buffer uses the given runes.
+func newBufferRunes(r *runes.Buffer) *Buffer {
+	return &Buffer{runes: r}
 }
 
 // Close closes the buffer and all of its editors.

--- a/re1/bench_test.go
+++ b/re1/bench_test.go
@@ -39,7 +39,7 @@ func benchmark(b *testing.B, re string, n int) {
 	b.ResetTimer()
 	b.SetBytes(int64(n))
 	for i := 0; i < b.N; i++ {
-		if ms, err := r.Match(rs, 0); err != nil || ms != nil {
+		if r.Match(rs, 0) != nil {
 			b.Fatal("match!")
 		}
 	}

--- a/re1/re1_test.go
+++ b/re1/re1_test.go
@@ -325,26 +325,24 @@ func TestReuse(t *testing.T) {
 	}
 	str := "abc"
 	want := []string{"abc", "a", "b", "c", "", "", ""}
-	ms, err := re.Match(sliceRunes([]rune(str)), 0)
-	got := matches(str, ms, false)
-	if err != nil || !reflect.DeepEqual(got, want) {
-		t.Fatalf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v,%v want %v, nil`, str, got, err, want)
+	got := matches(str, re.Match(sliceRunes([]rune(str)), 0), false)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v want %v, nil`, str, got, want)
 	}
 	// This will get different subexpression matches.
 	// Make sure that there isn't old data from the previous match.
 	str = "xyz"
 	want = []string{"xyz", "", "", "", "x", "y", "z"}
-	ms, err = re.Match(sliceRunes([]rune(str)), 0)
-	got = matches(str, ms, false)
-	if err != nil || !reflect.DeepEqual(got, want) {
-		t.Errorf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v,%v, want %v,vil`, str, got, err, want)
+	got = matches(str, re.Match(sliceRunes([]rune(str)), 0), false)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(`Compile("(a)(b)(c)|(x)(y)(z)").Match(%s)=%v, want %v,vil`, str, got, want)
 	}
 }
 
 type sliceRunes []rune
 
-func (s sliceRunes) Rune(i int64) (rune, error) { return s[i], nil }
-func (s sliceRunes) Size() int64                { return int64(len(s)) }
+func (s sliceRunes) Rune(i int64) rune { return s[i] }
+func (s sliceRunes) Size() int64       { return int64(len(s)) }
 
 var (
 	rev = Options{Reverse: true}
@@ -368,12 +366,10 @@ func (test *regexpTest) run(t *testing.T) {
 	if test.opts.Reverse {
 		str = reverse(test.str)
 	}
-	es, err := re.Match(sliceRunes([]rune(str)), test.from)
-	if err != nil {
-	}
+	es := re.Match(sliceRunes([]rune(str)), test.from)
 	ms := matches(test.str, es, test.opts.Reverse)
-	if err == nil && (es == nil && test.want == nil ||
-		len(es) == len(test.want) && reflect.DeepEqual(ms, test.want)) {
+	if es == nil && test.want == nil ||
+		len(es) == len(test.want) && reflect.DeepEqual(ms, test.want) {
 		return
 	}
 	got := "<nil>"


### PR DESCRIPTION
The interface is prettier without the error.
Instead of the original apporach of panicing on IO errors,
store errors in the Runes implementer and check it
before determining if a match succeeds.