### PR TITLE
Fix a deadlock between sdl2UI.do and window.event.

### DIFF
--- a/ui/play/main.go
+++ b/ui/play/main.go
@@ -54,9 +54,10 @@ func main() {
 	w1.Draw(d1)
 
 	tick := time.Tick(16 * time.Millisecond)
+	ev0, ev1 := w0.Events(), w1.Events()
 	for {
 		select {
-		case e := <-w0.Events():
+		case e := <-ev0:
 			switch e := e.(type) {
 			case ui.ButtonEvent:
 				d0.down = e.Down
@@ -68,7 +69,7 @@ func main() {
 			case ui.CloseEvent:
 				return
 			}
-		case e := <-w1.Events():
+		case e := <-ev1:
 			switch e := e.(type) {
 			case ui.ButtonEvent:
 				d1.down = e.Down
@@ -78,11 +79,12 @@ func main() {
 			case ui.MotionEvent:
 				d1.Max = e.Point
 			case ui.CloseEvent:
+				ev1 = nil
 				w1.Close()
 			}
 		case <-tick:
 			w0.Draw(d0)
-			if w1.Events() != nil {
+			if ev1 != nil {
 				w1.Draw(d1)
 			}
 		}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -23,7 +23,6 @@ type UI interface {
 type Window interface {
 	// Events returns a channel of the Window's events.
 	// The channel is closed when the Window is Closed.
-	// Events() returns nil when called on a closed Window.
 	Events() <-chan interface{}
 	// Draw calls the Draw method of a Drawer
 	// with a Canvas on this Window.
@@ -34,6 +33,9 @@ type Window interface {
 
 // A Canvas represents a portion of a Window.
 // It provides functionality for drawing on the Window.
+//
+// Metods on Canvas must only be called
+// from the go routine that calls Drawer.Draw.
 type Canvas interface {
 	// Bounds returns the bounds of the Canvas within its Window.
 	Bounds() image.Rectangle


### PR DESCRIPTION
There was a deadlock between sdl2UI.run and the main event loop
if the main event loop both send to sdl2UI.do (Window.Draw)
and also received from Window.Events().
The sdl2UI.run go routine would block sending on Window.Events()
and the main loop go routine would block sending on sdl2UI.do.
This is the classic dining philosophers problem.

To break the deadlock, I introduced a new go routine
that proxies events from sdl2UI.run
to the window's output event channel.
This way, the events are received in the order that they are sent
and sdl2UI.run never blocks sending an event—the proxy go routine
is always able to receive an event from sdl2UI.run.

Fixes #58.