### PR TITLE
Make the ui.Canvas API stateless.

### DIFF
--- a/ui/play/main.go
+++ b/ui/play/main.go
@@ -19,24 +19,21 @@ type drawer struct {
 }
 
 func (d drawer) Draw(c ui.Canvas) {
-	c.SetColor(color.Black)
-	c.Fill(c.Bounds())
-	c.Draw(image.ZP, d.tex)
+	c.Fill(color.Black, c.Bounds())
+	c.Draw(d.tex, image.ZP)
 
 	if !d.down {
 		return
 	}
 	p, q := d.Min, d.Max
-	c.SetColor(color.White)
 	if d.Max.X < d.Min.X {
 		d.Min.X, d.Max.X = d.Max.X, d.Min.X
 	}
 	if d.Max.Y < d.Min.Y {
 		d.Min.Y, d.Max.Y = d.Max.Y, d.Min.Y
 	}
-	c.Fill(d.Rectangle)
-	c.SetColor(color.RGBA{R: 255, A: 255})
-	c.Stroke(p, q)
+	c.Fill(color.White, d.Rectangle)
+	c.Stroke(color.RGBA{R: 255, A: 255}, p, q)
 }
 
 func main() {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -56,24 +56,21 @@ type Texture interface {
 type Canvas interface {
 	// Bounds returns the bounds of the Canvas within its Window.
 	Bounds() image.Rectangle
-	// SetColor sets the current drawing color.
-	// The default draw color is color.Black.
-	SetColor(color.Color)
 	// Fill fills the rectangular portion of the Canvas
-	// with the current drawing color.
-	Fill(image.Rectangle)
-	// Stroke strokes a single-pixel line between the points
-	// in the current drawing color.
-	Stroke(...image.Point)
+	// with the give color.
+	Fill(color.Color, image.Rectangle)
+	// Stroke strokes a single-pixel line between the points.
+	Stroke(color.Color, ...image.Point)
 	// Draw draws an image to the canvas.
-	// The first arguments specifies the point on the canvas
-	// to which the upper left corner of the image will be drawn.
+	// The point specifies the location on the Canvas
+	// to which the upper left corner of the image
+	// will be drawn.
 	//
 	// Draw can draw any image to the Canvas,
 	// but the most efficient way to draw an image
 	// is to use a Texture created by the Canvas's
 	// associated Window.
-	Draw(image.Point, image.Image)
+	Draw(image.Image, image.Point)
 }
 
 // A Drawer can draw itself to a Canvas.


### PR DESCRIPTION
This removes the SetColor method.
There are only two methods that need the color;
they can just take it as an argument.

I also swapped the order of the arguments to Canvas.Draw.
Fill and Stroke take the color first and the location second.
Draw should take the image, which specifies the colors,
first and the location second too.