### PR TITLE
Don't bother closing textures on exit.

### DIFF
--- a/ui/play/main.go
+++ b/ui/play/main.go
@@ -49,14 +49,12 @@ func main() {
 	w0 := u.NewWindow("Title", 800, 600)
 	var d0 drawer
 	d0.tex = w0.Texture(b.Dx(), b.Dy())
-	defer d0.tex.Close()
 	draw.Draw(d0.tex, b, png, image.ZP, draw.Over)
 	w0.Draw(d0)
 
 	w1 := u.NewWindow("Title", 640, 480)
 	var d1 drawer
 	d1.tex = w1.Texture(b.Dx(), b.Dy())
-	defer d1.tex.Close()
 	draw.Draw(d1.tex, b, png, image.ZP, draw.Over)
 	w1.Draw(d1)
 


### PR DESCRIPTION
Otherwise, we may close d1.tex in the defer
after w1 has been closed from the CloseEvent.
I don't think that's allowed,
and I think it's causing OSX to barf.

Fixes #65.