### PR TITLE
Add a two paranoid, substitute tests.

### DIFF
--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -344,6 +344,16 @@ func TestSubstituteEdit(t *testing.T) {
 			want: "abcdefghi ghi def abc", dot: addr{0, 21},
 		},
 		{
+			init: "...===...",
+			e:    Substitute{A: All, RE: "/(=*)/", With: `---\1---`},
+			want: "------...===...", dot: addr{0, 15},
+		},
+		{
+			init: "...===...",
+			e:    Substitute{A: All, RE: "/(=+)/", With: `---\1---`},
+			want: "...---===---...", dot: addr{0, 15},
+		},
+		{
 			init: "abc",
 			e:    Substitute{A: All, RE: "/abc/", With: `\1`},
 			want: "", dot: addr{0, 0},


### PR DESCRIPTION
I panicked because I thought
s/(=*)/---\1---/
on a buffer with
...===...
would give
...---===---...
It doesn't. I forgot that /(=*)/ can match ε. It just replaces the ε at the beginning of the buffer:
------...===...
This is not a bug. It's expected. Instead, use s/(=+)/---\1---/
These added tests simply remind us of this fact.