### PR TITLE
Update .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-go: 1.4
+go: 1.5
 
 notifications:
     email: false
@@ -9,14 +9,6 @@ env:
     - PATH=$HOME/gopath/bin:$PATH
 
 install:
-    # Install SDL2.
-    # Travis CI uses Ubuntu 12.04 which doesn't have libsdl2.
-    # We use SDL2-2.0.1, the minimum version with SDL_WINDOW_ALLOW_HIGHDPI.
-    - wget https://www.libsdl.org/release/SDL2-2.0.1.tar.gz
-    - tar -xzf SDL2-2.0.1.tar.gz
-    - (cd SDL2-2.0.1 && ./configure -q && make -s -j3 && sudo make install)
-
-    # Install go tools used by gok.sh
     - go get golang.org/x/tools/cmd/vet
     - go get github.com/golang/lint/golint
     - go get -d -v ./... && go build -v ./...


### PR DESCRIPTION
Use the latest version of Go, 1.5, and stop needlessly installing SDL.