### PR TITLE
Fix tmp files leaks.

### DIFF
--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -556,7 +556,7 @@ func TestIOErrors(t *testing.T) {
 		f := &errReaderAt{nil}
 		r := runes.NewBufferReaderWriterAt(1, f)
 		ed := NewEditor(newBuffer(r))
-		defer ed.Close()
+		defer ed.buf.Close()
 
 		if err := ed.buf.runes.Insert(rs, 0); err != nil {
 			t.Fatalf("ed.buf.runes.Insert(%v, 0)=%v, want nil", strconv.Quote(string(rs)), err)

--- a/edit/editor.go
+++ b/edit/editor.go
@@ -37,7 +37,7 @@ func newBuffer(rs *runes.Buffer) *Buffer {
 	}
 }
 
-// Close closes the Buffer.
+// Close closes the Buffer and any Editors editing it.
 // After Close is called, the Buffer is no longer editable.
 func (buf *Buffer) Close() error {
 	buf.Lock()
@@ -46,6 +46,9 @@ func (buf *Buffer) Close() error {
 		buf.runes.Close(),
 		buf.undo.close(),
 		buf.redo.close(),
+	}
+	for len(buf.eds) > 0 {
+		errs = append(errs, buf.eds[0].close())
 	}
 	for _, e := range errs {
 		if e != nil {
@@ -110,11 +113,13 @@ func NewEditor(buf *Buffer) *Editor {
 func (ed *Editor) Close() error {
 	ed.buf.Lock()
 	defer ed.buf.Unlock()
+	return ed.close()
+}
 
-	eds := ed.buf.eds
-	for i := range eds {
-		if eds[i] == ed {
-			ed.buf.eds = append(eds[:i], eds[:i+1]...)
+func (ed *Editor) close() error {
+	for i := range ed.buf.eds {
+		if ed.buf.eds[i] == ed {
+			ed.buf.eds = append(ed.buf.eds[:i], ed.buf.eds[i+1:]...)
 			return ed.pending.close()
 		}
 	}

--- a/edit/editor.go
+++ b/edit/editor.go
@@ -42,7 +42,17 @@ func newBuffer(rs *runes.Buffer) *Buffer {
 func (buf *Buffer) Close() error {
 	buf.Lock()
 	defer buf.Unlock()
-	return buf.runes.Close()
+	errs := []error{
+		buf.runes.Close(),
+		buf.undo.close(),
+		buf.redo.close(),
+	}
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
 }
 
 // Size returns the number of runes in the Buffer.

--- a/edit/editor_test.go
+++ b/edit/editor_test.go
@@ -26,7 +26,7 @@ func (ed *Editor) change(a Address, s string) error {
 
 func TestRetry(t *testing.T) {
 	ed := NewEditor(NewBuffer())
-	defer ed.Close()
+	defer ed.buf.Close()
 
 	const str = "Hello, 世界!"
 	ch := func() (addr, error) {

--- a/edit/log_test.go
+++ b/edit/log_test.go
@@ -134,6 +134,7 @@ func TestEntryStore(t *testing.T) {
 		{seq: 2, at: addr{20, 50}, str: "Hello, 世界"},
 	}
 	l := initTestLog(t, entries)
+	defer l.close()
 
 	// Modify an entry.
 	e1 := logFirst(l).next()
@@ -158,6 +159,7 @@ func TestEntryPop(t *testing.T) {
 		{seq: 2, str: "Testing 123"},
 	}
 	l := initTestLog(t, entries)
+	defer l.close()
 
 	seq2 := logLast(l)
 	if err := seq2.pop(); err != nil {

--- a/edit/runes/buffer_test.go
+++ b/edit/runes/buffer_test.go
@@ -227,6 +227,7 @@ func TestReaderFromFastPathShortReads(t *testing.T) {
 	src := &testShortReader{rs: rs, maxRead: len(rs) / 4}
 
 	dst := NewBuffer(testBlockSize * 2)
+	defer dst.Close()
 	n, err := dst.ReaderFrom(0).ReadFrom(src)
 	if n != int64(len(rs)) || err != nil {
 		t.Fatalf("dst.ReaderFrom(0).ReadFrom(src.Reader(0))=%d,%v, want %d,nil", n, err, len(rs))

--- a/gok.sh
+++ b/gok.sh
@@ -33,4 +33,7 @@ e=$(tempfile)
 touch $e
 diff $o $e > /dev/null || { rm $e; fail; }
 
+echo Leaks?
+ls /tmp | egrep "edit" 2>&1 > $o && fail
+
 rm $o $e


### PR DESCRIPTION
1) There were bugs in the Buffer Close code.
2) Lots of tests forgot to correctly close Buffers.
3) gok.sh now checks for leaks so they can be found more quickly.