### PR TITLE
Use mktemp instead of tempdir in gok.sh.

### DIFF
--- a/gok.sh
+++ b/gok.sh
@@ -3,7 +3,7 @@
 # Verifies that go code passes go fmt, go vet, golint, and go test.
 #
 
-o=$(tempfile)
+o=$(mktemp tmp.XXXXXXXXXX)
 
 fail() {
 	echo Failed


### PR DESCRIPTION
Fixes #117.