### PR TITLE
Change Ed and Addr to use io.RuneScanner.

### DIFF
--- a/edit/edit_example_test.go
+++ b/edit/edit_example_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 
 func ExampleAddress() {
@@ -18,7 +19,7 @@ func ExampleAddress() {
 	// It is intended to be called with runes input by a UI.
 	// This wrapper makes it a bit more friendly for our example.
 	parseAddr := func(s string) Address {
-		a, _, err := Addr([]rune(s))
+		a, err := Addr(strings.NewReader(s))
 		if err != nil {
 			panic(err)
 		}
@@ -99,7 +100,7 @@ func ExampleEdit() {
 	// It is intended to be called with runes input by a UI.
 	// This wrapper makes it a bit more friendly for our example.
 	parseEd := func(s string) Edit {
-		e, _, err := Ed([]rune(s))
+		e, err := Ed(strings.NewReader(s))
 		if err != nil {
 			panic(err)
 		}

--- a/re1/bench_test.go
+++ b/re1/bench_test.go
@@ -8,6 +8,7 @@ package re1
 
 import (
 	"math/rand"
+	"strings"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func makeRegexpText(n int) []byte {
 }
 
 func benchmark(b *testing.B, re string, n int) {
-	r, err := Compile([]rune(re), Options{})
+	r, err := Compile(strings.NewReader(re), Options{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
These functions used to take a []rune and return their result and the un-parsed, leftover runes. This made for lots of ugly slicing to track the leftover runes. It also limited the use of the functions.

Since there is no way before parsing with Ed or Addr to know when the edit or address end, it was impossible to parse an Edit or Address from an io.Reader. The best one could do was scan lines from the input and parse each line. But some crucial Edits span multiple lines (for example, the multi-line variants of c, i, and a).

Now, these functions take a io.RuneScanner. This has two improvements:
1) In my opinion, the code is more straight-forward. The io.RuneScanner tracks the left over runes, so it needn't be done explicitly.
2) Lots of things implement io.RuneScanner. To name a few:
	* strings.Buffer
	* bytes.Buffer
	* bufio.Reader (thus any io.Reader)
   All of these can now be used to parse Edits and Addresses.

There is one disadvantage. In re1, before this change, if the delimiter was also a metacharacter, then its escaped version was interpreted as the metacharacter, not as the literal. This was intended for reverse regular expression addresses where the delimiter is ?. The only way to use the meta-?, was to escape it:

?(reverse regxp address)\??

But! that required two tokens of look ahead; io.RuneScanner only allows for one. So, I removed this feature for now. Escaped metacharacters are always interpreted literally. To use the meta-? in a reverse regexp address, reverse the address with - and not ?, thusly:

-/(reverse regexp address)?/