### PR TITLE
Add tests for reversing regexps containing meta ?.

### DIFF
--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -216,6 +216,7 @@ func TestMinusAddress(t *testing.T) {
 		{text: "abc", addr: Rune(2).Minus(Rune(-1)), want: pt(3)},
 		{text: "abc\ndef", addr: Line(1).Minus(Line(1)), want: pt(0)},
 		{text: "abc\ndef", dot: rng(1, 6), addr: Dot.Minus(Line(1)).Plus(Line(1)), want: rng(0, 4)},
+		{text: "abc", dot: pt(3), addr: Dot.Minus(Regexp("/aa?/")), want: rng(0, 1)},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -287,7 +288,7 @@ func (test addressTest) run(t *testing.T) {
 	if a != test.want ||
 		(test.err == "" && errStr != "") ||
 		(test.err != "" && !regexp.MustCompile(test.err).MatchString(errStr)) {
-		t.Errorf(`Address("%q").range(%d, %q)=%v, %v, want %v, %v`,
+		t.Errorf(`Address(%q).range(%d, %q)=%v, %v, want %v, %v`,
 			test.addr.String(), test.dot, test.text, a, err,
 			test.want, test.err)
 	}
@@ -381,6 +382,9 @@ func TestAddr(t *testing.T) {
 		{a: " + - ", want: Dot.Plus(Line(1)).Minus(Line(1))},
 		{a: " - + ", want: Dot.Minus(Line(1)).Plus(Line(1))},
 		{a: "/abc/+++---", want: Regexp("/abc/").Plus(Line(1)).Plus(Line(1)).Plus(Line(1)).Minus(Line(1)).Minus(Line(1)).Minus(Line(1))},
+
+		{a: ".+/aa?/", want: Dot.Plus(Regexp("/aa?/"))},
+		{a: ".-/aa?/", want: Dot.Minus(Regexp("/aa?/"))},
 
 		{a: ",", want: Line(0).To(End)},
 		{a: ",xyz", left: "xyz", want: Line(0).To(End)},


### PR DESCRIPTION
2f57088c3e73e8325cf31b8831f946abd4e288d0 changed the way that escaped meta-character delimiters behave. Namely, they used to be interpreted as meta, but now they are interpreted as literal. There was concern that this would break Dot.Minus(Regexp("…")) addresses, where the regexp contained a meta ?. The worry was that, internally, Regexp addresses would switch the given delimiter to a ? to track the reversing. This would mean that any meta-? characters would be escaped and now be interpreted literally instead of meta. However Regexp does not work this way; whe reversing, it keeps the original delimiter. If the user used ? originally, then they had the new behavior of meta-? from the start; Regexp never changes it out from beneath them. The added tests verify.

However, we should switch back to the original behavior at some point.