### PR TITLE
Use re1.Regexp instead of string.

### DIFF
--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -12,6 +12,8 @@ package edit
 import (
 	"math/rand"
 	"testing"
+
+	"github.com/eaburns/T/re1"
 )
 
 // benchmark based on regexp/exec_test.go
@@ -53,10 +55,11 @@ func benchmarkLine(b *testing.B, n int) {
 func BenchmarkLinex32(b *testing.B) { benchmarkLine(b, 32<<0) }
 func BenchmarkLinex1K(b *testing.B) { benchmarkLine(b, 1<<10) }
 
-func benchmarkRegexp(b *testing.B, re string, n int) {
+func benchmarkRegexp(b *testing.B, regexp string, n int) {
 	ed, _ := makeEditor(n)
 	b.ResetTimer()
 	b.SetBytes(int64(n))
+	re := re1.Must(regexp)
 	for i := 0; i < b.N; i++ {
 		switch _, err := Regexp(re).where(ed); {
 		case err == nil:

--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/eaburns/T/edit/runes"
+	"github.com/eaburns/T/re1"
 )
 
 func TestDotAddress(t *testing.T) {
@@ -135,28 +136,27 @@ func TestLineAddress(t *testing.T) {
 
 func TestRegexpAddress(t *testing.T) {
 	tests := []addressTest{
-		{text: "Hello, 世界!", addr: Regexp("/"), want: pt(0)},
-		{text: "Hello, 世界!", addr: Regexp("/H"), want: rng(0, 1)},
-		{text: "Hello, 世界!", addr: Regexp("/."), want: rng(0, 1)},
-		{text: "Hello, 世界!", addr: Regexp("/世界"), want: rng(7, 9)},
-		{text: "Hello, 世界!", addr: Regexp("/[^!]+"), want: rng(0, 9)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("")), want: pt(0)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("H")), want: rng(0, 1)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must(".")), want: rng(0, 1)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("世界")), want: rng(7, 9)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("[^!]+")), want: rng(0, 9)},
 
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?"), want: pt(10)},
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?!"), want: rng(9, 10)},
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?."), want: rng(9, 10)},
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?H"), want: rng(0, 1)},
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?[^!]+"), want: rng(0, 9)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("?")), want: pt(10)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("?!")), want: rng(9, 10)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("?.")), want: rng(9, 10)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("?H")), want: rng(0, 1)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("?[^!]+")), want: rng(0, 9)},
 
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("/H").reverse(), want: rng(0, 1)},
-		{text: "Hello, 世界!", addr: Regexp("?H").reverse(), want: rng(0, 1)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp(re1.Must("H")).reverse(), want: rng(0, 1)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("?H")).reverse(), want: rng(0, 1)},
 
 		// Wrap.
-		{text: "Hello, 世界!", addr: Regexp("?世界"), want: rng(7, 9)},
-		{text: "Hello, 世界!", dot: pt(8), addr: Regexp("/世界"), want: rng(7, 9)},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("?世界")), want: rng(7, 9)},
+		{text: "Hello, 世界!", dot: pt(8), addr: Regexp(re1.Must("世界")), want: rng(7, 9)},
 
-		{text: "", addr: Regexp("/()"), err: "operand"},
-		{text: "Hello, 世界!", addr: Regexp("/☺"), err: "no match"},
-		{text: "Hello, 世界!", addr: Regexp("?☺"), err: "no match"},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("☺")), err: "no match"},
+		{text: "Hello, 世界!", addr: Regexp(re1.Must("?☺")), err: "no match"},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -168,25 +168,19 @@ func TestRegexpString(t *testing.T) {
 	tests := []struct {
 		re, want string
 	}{
-		{"", "//"},
-		{"/", "//"},
-		{"☺", "☺☺"},
-		{"//", "//"},
-		{"☺☺", "☺☺"},
-		{`/\/`, `/\//`},
-		{`☺\☺`, `☺\☺☺`},
-		{"/abc", "/abc/"},
-		{"/abc/", "/abc/"},
-		{"☺abc", "☺abc☺"},
-		{"☺abc☺", "☺abc☺"},
-		{"/abc", "/abc/"},
-		{`/abc\/`, `/abc\//`},
-		{`☺abc\☺`, `☺abc\☺☺`},
+		{``, `//`},
+		{`/`, `/\//`},
+		{`☺`, `/☺/`},
+		{`//`, `/\/\//`},
+		{`\/`, `/\//`},
+		{`abc\/`, `/abc\//`},
+		{`?`, `??`},
+		{`?abc`, `?abc?`},
 	}
 	for _, test := range tests {
-		re := Regexp(test.re)
+		re := Regexp(re1.Must(test.re))
 		if s := re.String(); s != test.want {
-			t.Errorf("Regexp(%q).String()=%q, want %q", test.re, s, test.want)
+			t.Errorf("Regexp(re1.Must(%q)).String()=%q, want %q", test.re, s, test.want)
 		}
 	}
 }
@@ -216,7 +210,7 @@ func TestMinusAddress(t *testing.T) {
 		{text: "abc", addr: Rune(2).Minus(Rune(-1)), want: pt(3)},
 		{text: "abc\ndef", addr: Line(1).Minus(Line(1)), want: pt(0)},
 		{text: "abc\ndef", dot: rng(1, 6), addr: Dot.Minus(Line(1)).Plus(Line(1)), want: rng(0, 4)},
-		{text: "abc", dot: pt(3), addr: Dot.Minus(Regexp("/aa?/")), want: rng(0, 1)},
+		{text: "abc", dot: pt(3), addr: Dot.Minus(Regexp(re1.Must("aa?"))), want: rng(0, 1)},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -231,13 +225,13 @@ func TestToAddress(t *testing.T) {
 		{text: "abc\ndef", addr: Line(1).To(Line(2)), want: rng(0, 7)},
 		{
 			text: "abcabc",
-			addr: Regexp("/abc").To(Regexp("/b")),
+			addr: Regexp(re1.Must("abc")).To(Regexp(re1.Must("b"))),
 			want: rng(0, 2),
 		},
 		{
 			text: "abc\ndef\nghi\njkl",
 			dot:  pt(11),
-			addr: Regexp("?abc?").Plus(Line(1)).To(Dot),
+			addr: Regexp(re1.Must("?abc")).Plus(Line(1)).To(Dot),
 			want: rng(4, 11),
 		},
 		{text: "abc\ndef", addr: Line(0).To(Line(1)).To(Line(2)), want: rng(0, 7)},
@@ -249,8 +243,8 @@ func TestToAddress(t *testing.T) {
 
 func TestThenAddress(t *testing.T) {
 	tests := []addressTest{
-		{text: "abcabc", addr: Regexp("/abc/").Then(Regexp("/b/")), want: rng(0, 5)},
-		{text: "abcabc", addr: Regexp("/abc/").Then(Dot.Plus(Rune(1))), want: rng(0, 4)},
+		{text: "abcabc", addr: Regexp(re1.Must("abc")).Then(Regexp(re1.Must("b"))), want: rng(0, 5)},
+		{text: "abcabc", addr: Regexp(re1.Must("abc")).Then(Dot.Plus(Rune(1))), want: rng(0, 4)},
 		{text: "abcabc", addr: Line(0).Plus(Rune(1)).Then(Dot.Plus(Rune(1))), want: rng(1, 2)},
 		{text: "abcabc", addr: Line(0).To(Rune(1)).Then(Dot.Plus(Rune(1))), want: rng(0, 2)},
 	}
@@ -330,19 +324,18 @@ func TestAddr(t *testing.T) {
 		{a: " 1\t\n\txyz", left: "\txyz", want: Line(1)},
 		{a: strconv.FormatInt(math.MaxInt64, 10) + "0", err: "out of range"},
 
-		{a: "/", want: Regexp("/")},
-		{a: "//", want: Regexp("//")},
-		{a: "?", want: Regexp("?")},
-		{a: "??", want: Regexp("??")},
-		{a: "/abcdef", want: Regexp("/abcdef")},
-		{a: "/abc/def", left: "def", want: Regexp("/abc/")},
-		{a: "/abc def", want: Regexp("/abc def")},
-		{a: "/abc def\nxyz", left: "xyz", want: Regexp("/abc def/")},
-		{a: "?abcdef", want: Regexp("?abcdef")},
-		{a: "?abc?def", left: "def", want: Regexp("?abc?")},
-		{a: "?abc def", want: Regexp("?abc def")},
-		{a: " ?abc def", want: Regexp("?abc def")},
-		{a: "?abc def\nxyz", left: "xyz", want: Regexp("?abc def?")},
+		{a: "/", want: Regexp(re1.Must(""))},
+		{a: "//", want: Regexp(re1.Must(""))},
+		{a: "?", want: Regexp(re1.Must("?"))},
+		{a: "/abcdef", want: Regexp(re1.Must("abcdef"))},
+		{a: "/abc/def", left: "def", want: Regexp(re1.Must("abc"))},
+		{a: "/abc def", want: Regexp(re1.Must("abc def"))},
+		{a: "/abc def\nxyz", left: "xyz", want: Regexp(re1.Must("abc def"))},
+		{a: "?abcdef", want: Regexp(re1.Must("?abcdef"))},
+		{a: "?abc?def", left: "def", want: Regexp(re1.Must("?abc"))},
+		{a: "?abc def", want: Regexp(re1.Must("?abc def"))},
+		{a: " ?abc def", want: Regexp(re1.Must("?abc def"))},
+		{a: "?abc def\nxyz", left: "xyz", want: Regexp(re1.Must("?abc def"))},
 		{a: "/()", err: "operand"},
 
 		{a: "$", want: End},
@@ -381,10 +374,10 @@ func TestAddr(t *testing.T) {
 		{a: "+-", want: Dot.Plus(Line(1)).Minus(Line(1))},
 		{a: " + - ", want: Dot.Plus(Line(1)).Minus(Line(1))},
 		{a: " - + ", want: Dot.Minus(Line(1)).Plus(Line(1))},
-		{a: "/abc/+++---", want: Regexp("/abc/").Plus(Line(1)).Plus(Line(1)).Plus(Line(1)).Minus(Line(1)).Minus(Line(1)).Minus(Line(1))},
+		{a: "/abc/+++---", want: Regexp(re1.Must("abc")).Plus(Line(1)).Plus(Line(1)).Plus(Line(1)).Minus(Line(1)).Minus(Line(1)).Minus(Line(1))},
 
-		{a: ".+/aa?/", want: Dot.Plus(Regexp("/aa?/"))},
-		{a: ".-/aa?/", want: Dot.Minus(Regexp("/aa?/"))},
+		{a: ".+/aa?/", want: Dot.Plus(Regexp(re1.Must("aa?")))},
+		{a: ".-/aa?/", want: Dot.Minus(Regexp(re1.Must("aa?")))},
 
 		{a: ",", want: Line(0).To(End)},
 		{a: ",xyz", left: "xyz", want: Line(0).To(End)},
@@ -416,23 +409,23 @@ func TestAddr(t *testing.T) {
 		// Implicit +.
 		{a: "1#2", want: Line(1).Plus(Rune(2))},
 		{a: "#2 1", want: Rune(2).Plus(Line(1))},
-		{a: "1/abc", want: Line(1).Plus(Regexp("/abc"))},
-		{a: "/abc/1", want: Regexp("/abc/").Plus(Line(1))},
-		{a: "?abc?1", want: Regexp("?abc?").Plus(Line(1))},
-		{a: "$?abc", want: End.Plus(Regexp("?abc"))},
+		{a: "1/abc", want: Line(1).Plus(Regexp(re1.Must("abc")))},
+		{a: "/abc/1", want: Regexp(re1.Must("abc")).Plus(Line(1))},
+		{a: "?abc?1", want: Regexp(re1.Must("?abc?")).Plus(Line(1))},
+		{a: "$?abc", want: End.Plus(Regexp(re1.Must("?abc")))},
 	}
 	for _, test := range tests {
 		rs := strings.NewReader(test.a)
 		a, err := Addr(rs)
 		if test.err != "" {
 			if !regexp.MustCompile(test.err).MatchString(err.Error()) {
-				t.Errorf(`Addr(%q)=%q,%q, want %q,%q`,
+				t.Errorf(`Addr(%q)=%q,%v, want %q,%q`,
 					test.a, a, err, test.want, test.err)
 			}
 			continue
 		}
 		if err != nil || !reflect.DeepEqual(a, test.want) {
-			t.Errorf(`Addr(%q)=%q,%q, want %q,%q`, test.a, a, err, test.want, test.err)
+			t.Errorf(`Addr(%q)=%q,%v, want %q,%q`, test.a, a, err, test.want, test.err)
 			continue
 		}
 		left, err := ioutil.ReadAll(rs)
@@ -514,16 +507,14 @@ func TestAddressString(t *testing.T) {
 		{addr: Line(-100), want: Dot.Minus(Line(100))},
 		{addr: Mark('a')},
 		{addr: Mark('z')},
-		{addr: Regexp("/☺☹")},
-		{addr: Regexp("/☺☹/")},
-		{addr: Regexp("?☺☹")},
-		{addr: Regexp("?☺☹?")},
+		{addr: Regexp(re1.Must("☺☹"))},
+		{addr: Regexp(re1.Must("?☺☹"))},
 		{addr: Dot.Plus(Line(1))},
 		{addr: Dot.Minus(Line(1))},
 		{addr: Dot.Minus(Line(1)).Plus(Line(1))},
 		{addr: Rune(1).To(Rune(2))},
 		{addr: Rune(1).Then(Rune(2))},
-		{addr: Regexp("/func").Plus(Regexp(`/\(`))},
+		{addr: Regexp(re1.Must("func")).Plus(Regexp(re1.Must(`\(`)))},
 	}
 	for _, test := range tests {
 		if test.want == nil {
@@ -531,7 +522,7 @@ func TestAddressString(t *testing.T) {
 		}
 		str := test.addr.String()
 		got, err := Addr(strings.NewReader(str))
-		if err != nil || got != test.want {
+		if err != nil || !reflect.DeepEqual(got, test.want) {
 			t.Errorf("Addr(%q)=%v,%v want %q,nil", str, got, err, test.want.String())
 			continue
 		}

--- a/edit/edit_example_test.go
+++ b/edit/edit_example_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/eaburns/T/re1"
 )
 
 func ExampleAddress() {
@@ -42,9 +44,9 @@ func ExampleAddress() {
 
 		// Regular expressions.
 		parseAddr("/Hello/"),
-		Regexp("/Hello/"),
+		Regexp(re1.Must("Hello")),
 		// A regular expression, searching in reverse.
-		Regexp("?Hello?"),
+		Regexp(re1.Must("?Hello?")),
 
 		// Line addresses.
 		parseAddr("1"),
@@ -56,9 +58,9 @@ func ExampleAddress() {
 
 		// Addresses relative to other addresses.
 		parseAddr("#0+/l/,#5"),
-		Rune(0).Plus(Regexp("/l")).To(Rune(5)),
+		Rune(0).Plus(Regexp(re1.Must("l"))).To(Rune(5)),
 		parseAddr("$-/l/,#5"),
-		End.Minus(Regexp("/l")).To(Rune(5)),
+		End.Minus(Regexp(re1.Must("l"))).To(Rune(5)),
 	}
 
 	// Print the contents of the editor at each address to os.Stdout.
@@ -117,7 +119,7 @@ func ExampleEdit() {
 		// Here is the same Edit built with a funciton.
 		Print(All),
 		// This prints a different address.
-		Print(Regexp("/,").Plus(Rune(1)).To(End)),
+		Print(Regexp(re1.Must(",")).Plus(Rune(1)).To(End)),
 
 		// c changes the buffer at a given address preceeding it.
 		// After this change, the buffer will contain: "Hello, 世界!\n"
@@ -126,7 +128,7 @@ func ExampleEdit() {
 
 		// Or you can do it with functions.
 		// After this change, the buffer will contain: "Hello, World!\n" again.
-		Change(Regexp("/世界"), "World"),
+		Change(Regexp(re1.Must("世界")), "World"),
 		Print(All),
 
 		// There is infinite Undo…
@@ -140,7 +142,7 @@ func ExampleEdit() {
 
 		// You can also edit with regexp substitution.
 		Change(All, "...===...\n"),
-		Sub(All, "/(=+)/", `---\1---`),
+		Sub(All, re1.Must("(=+)"), `---\1---`),
 		Print(All),
 		parseEd(`,s/\./_/g`),
 		Print(All),

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/eaburns/T/re1"
 )
 
 func TestEscape(t *testing.T) {
@@ -192,13 +194,13 @@ func TestMoveEdit(t *testing.T) {
 		{e: Move(Rune(1), Rune(2)), err: "address out of range"},
 		{init: "a", e: Move(Rune(1), Rune(2)), err: "address out of range"},
 
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(0)), want: "abc", dot: addr{0, 3}},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(1)), err: "overlap"},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(2)), err: "overlap"},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(3)), want: "abc", dot: addr{0, 3}},
-		{init: "abcdef", e: Move(Regexp("/abc/"), End), want: "defabc", dot: addr{3, 6}},
-		{init: "abcdef", e: Move(Regexp("/def/"), Line(0)), want: "defabc", dot: addr{0, 3}},
-		{init: "abc\ndef\nghi", e: Move(Regexp("/def/"), Line(3)), want: "abc\n\nghidef", dot: addr{8, 11}},
+		{init: "abc", e: Move(Regexp(re1.Must("abc")), Rune(0)), want: "abc", dot: addr{0, 3}},
+		{init: "abc", e: Move(Regexp(re1.Must("abc")), Rune(1)), err: "overlap"},
+		{init: "abc", e: Move(Regexp(re1.Must("abc")), Rune(2)), err: "overlap"},
+		{init: "abc", e: Move(Regexp(re1.Must("abc")), Rune(3)), want: "abc", dot: addr{0, 3}},
+		{init: "abcdef", e: Move(Regexp(re1.Must("abc")), End), want: "defabc", dot: addr{3, 6}},
+		{init: "abcdef", e: Move(Regexp(re1.Must("def")), Line(0)), want: "defabc", dot: addr{0, 3}},
+		{init: "abc\ndef\nghi", e: Move(Regexp(re1.Must("def")), Line(3)), want: "abc\n\nghidef", dot: addr{8, 11}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -210,11 +212,11 @@ func TestCopyEdit(t *testing.T) {
 		{e: Copy(Rune(1), Rune(2)), err: "address out of range"},
 		{init: "a", e: Copy(Rune(1), Rune(3)), err: "address out of range"},
 
-		{init: "abc", e: Copy(Regexp("/abc/"), End), want: "abcabc", dot: addr{3, 6}},
-		{init: "abc", e: Copy(Regexp("/abc/"), Line(0)), want: "abcabc", dot: addr{0, 3}},
-		{init: "abc", e: Copy(Regexp("/abc/"), Rune(1)), want: "aabcbc", dot: addr{1, 4}},
-		{init: "abcdef", e: Copy(Regexp("/abc/"), Rune(4)), want: "abcdabcef", dot: addr{4, 7}},
-		{init: "abc\ndef\nghi", e: Copy(Regexp("/def/"), Line(1)), want: "abc\ndefdef\nghi", dot: addr{4, 7}},
+		{init: "abc", e: Copy(Regexp(re1.Must("abc")), End), want: "abcabc", dot: addr{3, 6}},
+		{init: "abc", e: Copy(Regexp(re1.Must("abc")), Line(0)), want: "abcabc", dot: addr{0, 3}},
+		{init: "abc", e: Copy(Regexp(re1.Must("abc")), Rune(1)), want: "aabcbc", dot: addr{1, 4}},
+		{init: "abcdef", e: Copy(Regexp(re1.Must("abc")), Rune(4)), want: "abcdabcef", dot: addr{4, 7}},
+		{init: "abc\ndef\nghi", e: Copy(Regexp(re1.Must("def")), Line(1)), want: "abc\ndefdef\nghi", dot: addr{4, 7}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -233,7 +235,7 @@ func TestSetEdit(t *testing.T) {
 		{init: s, want: s, e: Set(All, '\t'), dot: addr{0, 10}},
 		{init: s, want: s, e: Set(All, 'a'), marks: map[rune]addr{'a': addr{0, 10}}},
 		{init: s, want: s, e: Set(All, 'α'), marks: map[rune]addr{'α': addr{0, 10}}},
-		{init: s, want: s, e: Set(Regexp("/Hello"), 'a'), marks: map[rune]addr{'a': addr{0, 5}}},
+		{init: s, want: s, e: Set(Regexp(re1.Must("Hello")), 'a'), marks: map[rune]addr{'a': addr{0, 5}}},
 		{init: s, want: s, e: Set(Line(0), 'z'), marks: map[rune]addr{'z': addr{0, 0}}},
 		{init: s, want: s, e: Set(End, 'm'), marks: map[rune]addr{'m': addr{10, 10}}},
 	}
@@ -250,9 +252,9 @@ func TestPrintEdit(t *testing.T) {
 		{e: Print(All), print: "", dot: addr{0, 0}},
 		{init: s, want: s, e: Print(All), print: s, dot: addr{0, 10}},
 		{init: s, want: s, e: Print(End), print: "", dot: addr{10, 10}},
-		{init: s, want: s, e: Print(Regexp("/H/")), print: "H", dot: addr{0, 1}},
-		{init: s, want: s, e: Print(Regexp("/Hello/")), print: "Hello", dot: addr{0, 5}},
-		{init: s, want: s, e: Print(Regexp("/世界/")), print: "世界", dot: addr{7, 9}},
+		{init: s, want: s, e: Print(Regexp(re1.Must("H"))), print: "H", dot: addr{0, 1}},
+		{init: s, want: s, e: Print(Regexp(re1.Must("Hello"))), print: "Hello", dot: addr{0, 5}},
+		{init: s, want: s, e: Print(Regexp(re1.Must("世界"))), print: "世界", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -271,8 +273,8 @@ func TestWhereEdit(t *testing.T) {
 		{init: s, want: s, e: Where(End), print: "#10", dot: addr{10, 10}},
 		{init: s, want: s, e: Where(Line(1)), print: "#0,#6", dot: addr{0, 6}},
 		{init: s, want: s, e: Where(Line(2)), print: "#6,#10", dot: addr{6, 10}},
-		{init: s, want: s, e: Where(Regexp("/Hello")), print: "#0,#5", dot: addr{0, 5}},
-		{init: s, want: s, e: Where(Regexp("/世界")), print: "#7,#9", dot: addr{7, 9}},
+		{init: s, want: s, e: Where(Regexp(re1.Must("Hello"))), print: "#0,#5", dot: addr{0, 5}},
+		{init: s, want: s, e: Where(Regexp(re1.Must("世界"))), print: "#7,#9", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -291,8 +293,8 @@ func TestWhereLinesEdit(t *testing.T) {
 		{init: s, want: s, e: WhereLine(End), print: "2", dot: addr{10, 10}},
 		{init: s, want: s, e: WhereLine(Line(1)), print: "1", dot: addr{0, 6}},
 		{init: s, want: s, e: WhereLine(Line(2)), print: "2", dot: addr{6, 10}},
-		{init: s, want: s, e: WhereLine(Regexp("/Hello")), print: "1", dot: addr{0, 5}},
-		{init: s, want: s, e: WhereLine(Regexp("/世界")), print: "2", dot: addr{7, 9}},
+		{init: s, want: s, e: WhereLine(Regexp(re1.Must("Hello"))), print: "1", dot: addr{0, 5}},
+		{init: s, want: s, e: WhereLine(Regexp(re1.Must("世界"))), print: "2", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -300,128 +302,140 @@ func TestWhereLinesEdit(t *testing.T) {
 }
 
 func TestSubstituteEdit(t *testing.T) {
+	abc := re1.Must("abc")
 	tests := []eTest{
-		{e: Sub(Rune(1), "/abc", "xyz"), err: "address out of range"},
-		{e: Substitute{A: All, RE: "/*/"}, err: "missing operand"},
+		{e: Sub(Rune(1), abc, "xyz"), err: "address out of range"},
 
 		{
 			init: "世界!",
-			e:    Substitute{A: All, RE: "", With: "Hello, "},
+			e:    Substitute{A: All, RE: re1.Must(""), With: "Hello, "},
 			want: "Hello, 世界!", dot: addr{0, 10},
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/.*/", With: "", Global: true},
+			e:    Substitute{A: All, RE: re1.Must(".*"), With: "", Global: true},
 			want: "", dot: addr{0, 0},
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/世界/", With: "World"},
+			e:    Substitute{A: All, RE: re1.Must("世界"), With: "World"},
 			want: "Hello, World!", dot: addr{0, 13},
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/(.)/", With: `\1-`, Global: true},
+			e:    Substitute{A: All, RE: re1.Must("(.)"), With: `\1-`, Global: true},
 			want: "H-e-l-l-o-,- -世-界-!-", dot: addr{0, 20},
 		},
 		{
 			init: "abcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg"},
+			e:    Substitute{A: All, RE: abc, With: "defg"},
 			want: "defgabc", dot: addr{0, 7},
 		},
 		{
+			init: "abcabc",
+			// Recompiles RE in the forward direction.
+			e:    Substitute{A: All, RE: re1.Must("?abc"), With: "defg"},
+			want: "defgabc", dot: addr{0, 7},
+		},
+		{
+			init: "aaa",
+			// Recompiles RE with Literal=false.
+			e:    Substitute{A: All, RE: re1.Must("!a*"), With: "bbb"},
+			want: "bbb", dot: addr{0, 3},
+		},
+		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: All, RE: abc, With: "defg", Global: true},
 			want: "defgdefgdefg", dot: addr{0, 12},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: Regexp("/abcabc/"), RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: Regexp(re1.Must("abcabc")), RE: abc, With: "defg", Global: true},
 			want: "defgdefgabc", dot: addr{0, 8},
 		},
 		{
 			init: "abc abc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg"},
+			e:    Substitute{A: All, RE: abc, With: "defg"},
 			want: "defg abc", dot: addr{0, 8},
 		},
 		{
 			init: "abc abc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: All, RE: abc, With: "defg", Global: true},
 			want: "defg defg", dot: addr{0, 9},
 		},
 		{
 			init: "abc abc abc",
-			e:    Substitute{A: Regexp("/abc abc/"), RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: Regexp(re1.Must("abc abc")), RE: abc, With: "defg", Global: true},
 			want: "defg defg abc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "de"},
+			e:    Substitute{A: All, RE: abc, With: "de"},
 			want: "deabc", dot: addr{0, 5},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "de", Global: true},
+			e:    Substitute{A: All, RE: abc, With: "de", Global: true},
 			want: "dedede", dot: addr{0, 6},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: Regexp("/abcabc/"), RE: "/abc/", With: "de", Global: true},
+			e:    Substitute{A: Regexp(re1.Must("abcabc")), RE: abc, With: "de", Global: true},
 			want: "dedeabc", dot: addr{0, 4},
 		},
 		{
 			init: "func f()",
-			e:    Substitute{A: All, RE: `/func (.*)\(\)/`, With: `func (T) \1()`, Global: true},
+			e:    Substitute{A: All, RE: re1.Must(`func (.*)\(\)`), With: `func (T) \1()`, Global: true},
 			want: "func (T) f()", dot: addr{0, 12},
 		},
 		{
 			init: "abcdefghi",
-			e:    Substitute{A: All, RE: "/(abc)(def)(ghi)/", With: `\0 \3 \2 \1`},
+			e:    Substitute{A: All, RE: re1.Must("(abc)(def)(ghi)"), With: `\0 \3 \2 \1`},
 			want: "abcdefghi ghi def abc", dot: addr{0, 21},
 		},
 		{
 			init: "...===...",
-			e:    Substitute{A: All, RE: "/(=*)/", With: `---\1---`},
+			e:    Substitute{A: All, RE: re1.Must("(=*)"), With: `---\1---`},
 			want: "------...===...", dot: addr{0, 15},
 		},
 		{
 			init: "...===...",
-			e:    Substitute{A: All, RE: "/(=+)/", With: `---\1---`},
+			e:    Substitute{A: All, RE: re1.Must("(=+)"), With: `---\1---`},
 			want: "...---===---...", dot: addr{0, 15},
 		},
 		{
 			init: "abc",
-			e:    Substitute{A: All, RE: "/abc/", With: `\1`},
+			e:    Substitute{A: All, RE: abc, With: `\1`},
 			want: "", dot: addr{0, 0},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 0},
+			e:    Substitute{A: All, RE: abc, With: "def", From: 0},
 			want: "defabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 1},
+			e:    Substitute{A: All, RE: abc, With: "def", From: 1},
 			want: "defabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 2},
+			e:    Substitute{A: All, RE: abc, With: "def", From: 2},
 			want: "abcdefabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", Global: true, From: 2},
+			e:    Substitute{A: All, RE: abc, With: "def", Global: true, From: 2},
 			want: "abcdefdef", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/notpresent/", With: "def", From: 4},
+			e:    Substitute{A: All, RE: re1.Must("notpresent"), With: "def", From: 4},
 			want: "abcabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 4},
+			e:    Substitute{A: All, RE: abc, With: "def", From: 4},
 			want: "abcabcabc", dot: addr{0, 9},
 		},
 	}
@@ -709,7 +723,7 @@ func TestUndoEdit(t *testing.T) {
 			name: "multi-change undo",
 			init: []Edit{
 				Append(End, "a.a.a"),
-				SubGlobal(All, "/[.]/", "z"),
+				SubGlobal(All, re1.Must("[.]"), "z"),
 			},
 			e:     Undo(1),
 			want:  "a.a.a",
@@ -719,8 +733,8 @@ func TestUndoEdit(t *testing.T) {
 			name: "undo maintains marks",
 			init: []Edit{
 				Append(End, "abcXXX"),
-				Set(Regexp("/XXX"), 'm'),
-				Delete(Regexp("/b")),
+				Set(Regexp(re1.Must("XXX")), 'm'),
+				Delete(Regexp(re1.Must("b"))),
 			},
 			e:    Undo(1),
 			want: "abcXXX",
@@ -795,7 +809,7 @@ func TestRedoEdit(t *testing.T) {
 			name: "multi-change redo",
 			init: []Edit{
 				Append(End, "a.a.a"),
-				SubGlobal(All, "/[.]/", "z"),
+				SubGlobal(All, re1.Must("[.]"), "z"),
 				Undo(1),
 			},
 			e:     Redo(1),
@@ -806,8 +820,8 @@ func TestRedoEdit(t *testing.T) {
 			name: "redo maintains marks",
 			init: []Edit{
 				Append(End, "abcXXX"),
-				Set(Regexp("/XXX"), 'm'),
-				Delete(Regexp("/b")),
+				Set(Regexp(re1.Must("XXX")), 'm'),
+				Delete(Regexp(re1.Must("b"))),
 				Undo(1),
 			},
 			e:    Redo(1),
@@ -885,6 +899,7 @@ func (test *undoTest) run1(t *testing.T) {
 }
 
 func TestEd(t *testing.T) {
+	a := re1.Must("a")
 	tests := []struct {
 		e, left string
 		want    Edit
@@ -900,7 +915,7 @@ func TestEd(t *testing.T) {
 		{e: "#0+1", want: Set(Rune(0).Plus(Line(1)), '.')},
 		{e: " #0 + 1 ", want: Set(Rune(0).Plus(Line(1)), '.')},
 		{e: "#0+1\nc/abc", left: "c/abc", want: Set(Rune(0).Plus(Line(1)), '.')},
-		{e: "/abc\n1c/xyz", left: "1c/xyz", want: Set(Regexp("/abc/"), '.')},
+		{e: "/abc\n1c/xyz", left: "1c/xyz", want: Set(Regexp(re1.Must("abc")), '.')},
 
 		{e: "k", want: Set(Dot, '.')},
 		{e: " k ", want: Set(Dot, '.')},
@@ -971,8 +986,8 @@ func TestEd(t *testing.T) {
 		{e: "d  \nxyz", left: "xyz", want: Delete(Dot)},
 
 		{e: "m", want: Move(Dot, Dot)},
-		{e: "m/abc/", want: Move(Dot, Regexp("/abc/"))},
-		{e: "/abc/m/def/", want: Move(Regexp("/abc/"), Regexp("/def/"))},
+		{e: "m/abc/", want: Move(Dot, Regexp(re1.Must("abc")))},
+		{e: "/abc/m/def/", want: Move(Regexp(re1.Must("abc")), Regexp(re1.Must("def")))},
 		{e: "#1+1m$", want: Move(Rune(1).Plus(Line(1)), End)},
 		{e: " #1 + 1 m $", want: Move(Rune(1).Plus(Line(1)), End)},
 		{e: "1m$xyz", left: "xyz", want: Move(Line(1), End)},
@@ -980,8 +995,8 @@ func TestEd(t *testing.T) {
 		{e: "m" + strconv.FormatInt(math.MaxInt64, 10) + "0", err: "value out of range"},
 
 		{e: "t", want: Copy(Dot, Dot)},
-		{e: "t/abc/", want: Copy(Dot, Regexp("/abc/"))},
-		{e: "/abc/t/def/", want: Copy(Regexp("/abc/"), Regexp("/def/"))},
+		{e: "t/abc/", want: Copy(Dot, Regexp(re1.Must("abc")))},
+		{e: "/abc/t/def/", want: Copy(Regexp(re1.Must("abc")), Regexp(re1.Must("def")))},
 		{e: "#1+1t$", want: Copy(Rune(1).Plus(Line(1)), End)},
 		{e: " #1 + 1 t $", want: Copy(Rune(1).Plus(Line(1)), End)},
 		{e: "1t$xyz", left: "xyz", want: Copy(Line(1), End)},
@@ -1003,25 +1018,25 @@ func TestEd(t *testing.T) {
 		{e: "#1+1=#", want: Where(Rune(1).Plus(Line(1)))},
 		{e: " #1 + 1 =#", want: Where(Rune(1).Plus(Line(1)))},
 
-		{e: "s/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "s;a;b", want: Sub(Dot, ";a;", "b")},
-		{e: "s/a//", want: Sub(Dot, "/a/", "")},
-		{e: "s/a/\n/g", left: "/g", want: Sub(Dot, "/a/", "")},
-		{e: "s/(.*)/a\\1", want: Sub(Dot, "/(.*)/", "a\\1")},
-		{e: ".s/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "#1+1s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: "s/a/b/xyz", left: "xyz", want: Sub(Dot, "/a/", "b")},
-		{e: "s/a/b\nxyz", left: "xyz", want: Sub(Dot, "/a/", "b")},
-		{e: "s1/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "s/a/b/g", want: SubGlobal(Dot, "/a/", "b")},
-		{e: " #1 + 1 s/a/b/g", want: SubGlobal(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: "s2/a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 2}},
-		{e: "s2;a;b", want: Substitute{A: Dot, RE: ";a;", With: "b", From: 2}},
-		{e: "s1000/a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 1000}},
-		{e: "s 2 /a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 2}},
-		{e: "s 1000 /a/b/g", want: Substitute{A: Dot, RE: "/a/", With: "b", Global: true, From: 1000}},
+		{e: "s/a/b", want: Sub(Dot, a, "b")},
+		{e: "s;a;b", want: Sub(Dot, a, "b")},
+		{e: "s/a//", want: Sub(Dot, a, "")},
+		{e: "s/a/\n/g", left: "/g", want: Sub(Dot, a, "")},
+		{e: "s/(.*)/a\\1", want: Sub(Dot, re1.Must("(.*)"), "a\\1")},
+		{e: ".s/a/b", want: Sub(Dot, a, "b")},
+		{e: "#1+1s/a/b", want: Sub(Rune(1).Plus(Line(1)), a, "b")},
+		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), a, "b")},
+		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), a, "b")},
+		{e: "s/a/b/xyz", left: "xyz", want: Sub(Dot, a, "b")},
+		{e: "s/a/b\nxyz", left: "xyz", want: Sub(Dot, a, "b")},
+		{e: "s1/a/b", want: Sub(Dot, a, "b")},
+		{e: "s/a/b/g", want: SubGlobal(Dot, a, "b")},
+		{e: " #1 + 1 s/a/b/g", want: SubGlobal(Rune(1).Plus(Line(1)), a, "b")},
+		{e: "s2/a/b", want: Substitute{A: Dot, RE: a, With: "b", From: 2}},
+		{e: "s2;a;b", want: Substitute{A: Dot, RE: a, With: "b", From: 2}},
+		{e: "s1000/a/b", want: Substitute{A: Dot, RE: a, With: "b", From: 1000}},
+		{e: "s 2 /a/b", want: Substitute{A: Dot, RE: a, With: "b", From: 2}},
+		{e: "s 1000 /a/b/g", want: Substitute{A: Dot, RE: a, With: "b", Global: true, From: 1000}},
 		{e: "s/", err: "missing pattern"},
 		{e: "s//b", err: "missing pattern"},
 		{e: "s/\n/b", err: "missing pattern"},
@@ -1090,14 +1105,14 @@ func TestEd(t *testing.T) {
 		e, err := Ed(rs)
 
 		if test.err != "" {
-			if !regexp.MustCompile(test.err).MatchString(err.Error()) {
-				t.Errorf(`Ed(%q)=%q,%q, want %q,%q`, test.e, e, err, test.want, test.err)
+			if err == nil || !regexp.MustCompile(test.err).MatchString(err.Error()) {
+				t.Errorf(`Ed(%q)=%q,%v, want %q,%q`, test.e, e, err, test.want, test.err)
 			}
 			continue
 		}
 
 		if err != nil || !reflect.DeepEqual(e, test.want) {
-			t.Errorf(`Ed(%q)=%q,%q, want %q,%q`, test.e, e, err, test.want, test.err)
+			t.Errorf(`Ed(%q)=%q,%v, want %q,%q`, test.e, e, err, test.want, test.err)
 			continue
 		}
 		left, err := ioutil.ReadAll(rs)

--- a/edit/editor_test.go
+++ b/edit/editor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/eaburns/T/edit/runes"
+	"github.com/eaburns/T/re1"
 )
 
 // String returns a string containing the entire editor contents.
@@ -70,8 +71,8 @@ func TestWhere(t *testing.T) {
 		{init: "Hello\n 世界!", a: End, at: addr{10, 10}},
 		{init: "Hello\n 世界!", a: Line(1), at: addr{0, 6}},
 		{init: "Hello\n 世界!", a: Line(2), at: addr{6, 10}},
-		{init: "Hello\n 世界!", a: Regexp("/Hello"), at: addr{0, 5}},
-		{init: "Hello\n 世界!", a: Regexp("/世界"), at: addr{7, 9}},
+		{init: "Hello\n 世界!", a: Regexp(re1.Must("Hello")), at: addr{0, 5}},
+		{init: "Hello\n 世界!", a: Regexp(re1.Must("世界")), at: addr{7, 9}},
 	}
 	for _, test := range tests {
 		ed := NewEditor(NewBuffer())
@@ -97,7 +98,7 @@ func TestWriterTo(t *testing.T) {
 		{init: "", a: End, want: "", dot: addr{}},
 		{init: "", a: Rune(0), want: "", dot: addr{}},
 		{init: "Hello, 世界", a: All, want: "Hello, 世界", dot: addr{0, 9}},
-		{init: "Hello, 世界", a: Regexp("/Hello/"), want: "Hello", dot: addr{0, 5}},
+		{init: "Hello, 世界", a: Regexp(re1.Must("Hello")), want: "Hello", dot: addr{0, 5}},
 		{init: "Hello, 世界", a: End, want: "", dot: addr{9, 9}},
 		{init: "Hello, 世界", a: Rune(0), want: "", dot: addr{}},
 		{init: "a\nb\nc\n", a: Line(0), want: "", dot: addr{}},
@@ -141,7 +142,7 @@ func TestReaderFrom(t *testing.T) {
 		{init: "Hello, 世界", a: End, read: "", want: "Hello, 世界", dot: addr{9, 9}},
 		{init: "Hello, 世界", a: All, read: "", want: "", dot: addr{0, 0}},
 		{init: "Hello, 世界", a: All, read: "αβξ", want: "αβξ", dot: addr{0, 3}},
-		{init: "Hello, 世界", a: Regexp("/世界/"), read: "World", want: "Hello, World", dot: addr{7, 12}},
+		{init: "Hello, 世界", a: Regexp(re1.Must("世界")), read: "World", want: "Hello, World", dot: addr{7, 12}},
 		{init: "a\nb\nc\n", a: Line(0), read: "z\n", want: "z\na\nb\nc\n", dot: addr{0, 2}},
 		{init: "a\nb\nc\n", a: Line(1), read: "z\n", want: "z\nb\nc\n", dot: addr{0, 2}},
 		{init: "a\nb\nc\n", a: Line(2), read: "z\n", want: "a\nz\nc\n", dot: addr{2, 4}},

--- a/re1/re1.go
+++ b/re1/re1.go
@@ -54,9 +54,49 @@ type Regexp struct {
 	// counting the 0th, which is the entire expression.
 	nsub int
 
+	// Str is the non-delimited string representation of the Regexp.
+	str string
+	// Opts are the options used to compile the Regexp.
+	opts Options
+
 	lock   sync.Mutex
 	mcache []*machine
 }
+
+// String returns the non-delimited string representation of the Regexp.
+func (re *Regexp) String() string { return re.str }
+
+// DelimitedString returns the string representation of the Regexp delimited by d.
+// The returned string has both a leading and trailing delimiter.
+// Both \ and ] are invalid delimiters and will cause a panic.
+//
+// Note that while ] is invalid for DelimitedString, it is acceptable for Compile:
+// 	re1.Compile("]abc]", Options{Delimited:true})
+func (re *Regexp) DelimitedString(d rune) string {
+	// \ is impossible, because we can't escape it if it is a delimiter itself.
+	// It is always a bad delimiter.
+	// ] is an accptable delimiter in general, but we cannot accept it here.
+	// It is impossible because ] can appear escaped in a character class.
+	// To delimit [abc\]], we must convert it to ([abc]|\]).
+	// But ( and ) are capturing; we would need non-capturing groups.
+	if d == '\\' || d == ']' {
+		panic("bad delimiter: " + string(d))
+	}
+	return addDelim(d, re.str)
+}
+
+// Options returns the options used to compile the Regexp,
+// but with Delimited set to false
+// regardless of its value during compilation.
+// This special handling of Delimited allows reflect.DeepEqual
+// to compare regular expressions as equal
+// regardless of whether they were compiled with a delimiter or not.
+// For example,
+// 	/abc/
+// will equal
+//	abc
+// if the first is compiled with Options{Delimited:true}.
+func (re *Regexp) Options() Options { return re.opts }
 
 type node struct {
 	n   int
@@ -126,11 +166,15 @@ func (classLabel) epsilon() bool { return false }
 type Options struct {
 	// Delimited states whether the first character
 	// in the string should be interpreted as a delimiter.
+	// The rune \ is an invalid delimiter.
 	Delimited bool
-	// Reverse states whether the regular expression
-	// should be compiled for reverse match.
+	// Reverse states whether to compile regular expression in reverse.
+	// A reverse regular expression will match the regular expression
+	// if passed the input in reverse order.
+	// For example, "a*bc" will match the input sequence "cbaaaa".
 	Reverse bool
 	// Literal states whether metacharacters should be interpreted as literals.
+	// If Literal is true, the compiled Regexp matches the exact input string.
 	Literal bool
 }
 
@@ -151,7 +195,14 @@ func Compile(rs io.RuneScanner, opts Options) (*Regexp, error) {
 		re.start.out[0].to = re.end
 	}
 	re = subexpr(re, 0)
+	re.opts = opts
+	re.opts.Delimited = false
 	re.nsub = p.nsub
+	if opts.Delimited {
+		re.str = rmDelim(p.scanned)
+	} else {
+		re.str = string(p.scanned)
+	}
 	numberStates(re)
 	return re, nil
 }
@@ -174,6 +225,63 @@ func numberStates(re *Regexp) {
 			stk = append(stk, t)
 		}
 	}
+}
+
+func rmDelim(rs []rune) string {
+	if len(rs) == 0 {
+		return ""
+	}
+	var s []rune
+	var d rune
+	var esc, class bool
+	d, rs = rs[0], rs[1:]
+	for _, r := range rs {
+		if !esc && !class && r == d {
+			return string(s)
+		}
+		if esc && r == d {
+			// Escaped delimiter, strip the escape.
+			s = s[:len(s)-1]
+		}
+		s = append(s, r)
+		if r == '[' {
+			class = true
+		} else if class && r == ']' {
+			class = false
+		}
+		esc = !esc && r == '\\'
+	}
+	return string(s)
+}
+
+func addDelim(d rune, rs string) string {
+	s := []rune{d}
+	var esc, class bool
+	for _, r := range rs {
+		if r == d && !class {
+			if esc && strings.ContainsRune(Meta, d) {
+				// Change escaped meta characters matching the delimiter
+				// to character classes.
+				s = append(s[:len(s)-1], '[', d, ']')
+				esc = false
+				continue
+			}
+			if !esc {
+				s = append(s, '\\')
+			}
+		}
+		s = append(s, r)
+		if r == '[' {
+			class = true
+		} else if class && r == ']' {
+			class = false
+		}
+		esc = !esc && r == '\\'
+	}
+	if esc {
+		s = append(s, '\\')
+	}
+	return string(append(s, d))
 }
 
 type token rune
@@ -209,6 +317,7 @@ type parser struct {
 	delim   rune
 	current token
 	scanner io.RuneScanner
+	scanned []rune
 }
 
 func newParser(rs io.RuneScanner, opts Options) (*parser, error) {
@@ -220,9 +329,10 @@ func newParser(rs io.RuneScanner, opts Options) (*parser, error) {
 		case err != nil:
 			return nil, err
 		case r == '\\':
-			return nil, errors.New("bad delimiter")
+			return nil, errors.New("bad delimiter: " + string(r))
 		default:
 			p.delim = r
+			p.scanned = append(p.scanned, r)
 		}
 	}
 	return &p, p.next()
@@ -230,6 +340,9 @@ func newParser(rs io.RuneScanner, opts Options) (*parser, error) {
 
 func (p *parser) read() (rune, error) {
 	r, _, err := p.scanner.ReadRune()
+	if err == nil {
+		p.scanned = append(p.scanned, r)
+	}
 	return r, err
 }
 

--- a/re1/re1.go
+++ b/re1/re1.go
@@ -178,6 +178,32 @@ type Options struct {
 	Literal bool
 }
 
+// Must returns a compiled Regexp, or panics.
+//
+// The first rune of the string
+// determines the compilation options:
+// If the first rune is ?, the options are Options{Delimited: true, Reverse: true}.
+// If the first rune is !, the options are Options{Delimited: true, Literal: true}.
+// Otherwise the options are Options{}.
+// Character classes can be used to begin a regular expression
+// with one of these characters using the default Options{}.
+// For example:
+// 	[!]abc
+// is compiled with Options{}, not Options{Delimited: true, Literal: true}.
+func Must(s string) *Regexp {
+	var opts Options
+	if len(s) > 0 && s[0] == '?' {
+		opts = Options{Delimited: true, Reverse: true}
+	} else if len(s) > 0 && s[0] == '!' {
+		opts = Options{Delimited: true, Literal: true}
+	}
+	re, err := Compile(strings.NewReader(s), opts)
+	if err != nil {
+		panic(err)
+	}
+	return re
+}
+
 // Compile compiles a regular expression using the options.
 // The regular expression is parsed until either
 // the end of the input or an un-escaped closing delimiter.

--- a/re1/re1_test.go
+++ b/re1/re1_test.go
@@ -760,3 +760,33 @@ func TestDelimitedString(t *testing.T) {
 		}
 	}
 }
+
+// TestDeepEqual verifies that reflect.DeepEqual is happy with re1.Regexps.
+func TestDeepEqual(t *testing.T) {
+	regexps := []string{
+		"",
+		"a*",
+		"(a|b|c)",
+		"[xyz]$",
+		"^.+a?$",
+		`(\/\*(([^*\/]|\n)|([^*]|\n)\/|\*([^\/]|\n))*\*\/)`,
+	}
+	for _, a := range regexps {
+		for _, b := range regexps {
+			rea, err := Compile(strings.NewReader(a), Options{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			reb, err := Compile(strings.NewReader(b), Options{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			want := a == b
+			got := reflect.DeepEqual(rea, reb)
+			if got != want {
+				t.Errorf("reflect.DeepEqual(%q, %q)=%v, want %v", a, b, got, want)
+			}
+		}
+	}
+}

--- a/re1/re1_test.go
+++ b/re1/re1_test.go
@@ -249,7 +249,7 @@ func TestDelimitedMatch(t *testing.T) {
 		{opts: del, re: `[\[1-5]*[(would be error`, str: "1", want: []string{"1"}},
 		{opts: del, re: `[abc\[[]`, str: "abc[", want: []string{"abc["}},
 
-		{opts: del, re: `][1-5\]*`, str: "[1-9", want: []string{""}},
+		{opts: del, re: `][1-5\]*`, str: "[1-5", want: []string{""}},
 		{opts: del, re: `][1-5\]*`, str: "12345", want: []string{"12345"}},
 		{opts: del, re: `][1-5\]*](would be error`, str: "1", want: []string{"1"}},
 		{opts: del, re: `]abc[[\]`, str: "abc[", want: []string{"abc["}},
@@ -385,11 +385,32 @@ type regexpTest struct {
 }
 
 func (test *regexpTest) run(t *testing.T) {
-	re, err := Compile(strings.NewReader(test.re), test.opts)
-	if err != nil {
-		t.Fatalf(`Compile("%s", %+v)=%v, want nil`, test.re, test.opts, err)
+	name := test.re
+	re := test.run1(name, t)
+	if re == nil {
+		return
 	}
 
+	test.re = re.String()
+	test.opts.Delimited = false
+	test.run1(name+" from String()", t)
+
+	for _, d := range "/" + Meta {
+		if d == '\\' || d == ']' {
+			continue
+		}
+		test.re = re.DelimitedString(d)
+		test.opts.Delimited = true
+		test.run1(name+" from DelimitedString("+string(d)+")", t)
+	}
+}
+
+func (test *regexpTest) run1(name string, t *testing.T) *Regexp {
+	re, err := Compile(strings.NewReader(test.re), test.opts)
+	if err != nil {
+		t.Fatalf(`%s Compile("%s", %+v)=%v, want nil`, name, test.re, test.opts, err)
+		return nil
+	}
 	str := test.str
 	if test.opts.Reverse {
 		str = reverse(test.str)
@@ -398,7 +419,7 @@ func (test *regexpTest) run(t *testing.T) {
 	ms := matches(test.str, es, test.opts.Reverse)
 	if es == nil && test.want == nil ||
 		len(es) == len(test.want) && reflect.DeepEqual(ms, test.want) {
-		return
+		return re
 	}
 	got := "<nil>"
 	if es != nil {
@@ -408,8 +429,9 @@ func (test *regexpTest) run(t *testing.T) {
 	if test.want != nil {
 		want = fmt.Sprintf("%v", test.want)
 	}
-	t.Errorf(`Compile("%s", %+v).Match("%s", %d)=%v,%v, want %s`,
-		test.re, test.opts, test.str, test.from, got, err, want)
+	t.Errorf(`%s Compile("%s", %+v).Match("%s", %d)=%v,%v, want %s`,
+		name, test.re, test.opts, test.str, test.from, got, err, want)
+	return re
 }
 
 func matches(str string, es [][2]int64, rev bool) []string {
@@ -536,6 +558,205 @@ func TestParseErrors(t *testing.T) {
 		}
 		if re == nil {
 			continue
+		}
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name    string
+		in, out string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			out:  "",
+		},
+		{
+			name: "no ending delimiter",
+			in:   "/abc",
+			out:  "abc",
+		},
+		{
+			name: "ending delimiter",
+			in:   "/abc/",
+			out:  "abc",
+		},
+		{
+			name: "escaped delimiter",
+			in:   `/ab\/c`,
+			out:  `ab/c`,
+		},
+		{
+			name: "escaped delimiter at start",
+			in:   `/\/abc`,
+			out:  `/abc`,
+		},
+		{
+			name: "escaped delimiter at end",
+			in:   `/abc\/`,
+			out:  `abc/`,
+		},
+		{
+			name: "charclass delimiter",
+			in:   `/ab[/]c`,
+			out:  `ab[/]c`,
+		},
+		{
+			name: "escaped and charclass delimiter",
+			in:   `/a\/b[/]c/`,
+			out:  `a/b[/]c`,
+		},
+		{
+			name: "non-ASCII delimiter",
+			in:   `☺abc☺`,
+			out:  `abc`,
+		},
+		{
+			name: "escaped and charclass non-ASCII delimiter",
+			in:   `☺a\☺b[☺]c☺`,
+			out:  `a☺b[☺]c`,
+		},
+		{
+			name: "[ in charclass",
+			in:   `/abc[[/]`,
+			out:  `abc[[/]`,
+		},
+		{
+			name: "escaped ] in charclass",
+			in:   `/abc[/\]]`,
+			out:  `abc[/\]]`,
+		},
+		{
+			name: "trailing escape",
+			in:   `/abc\`,
+			out:  `abc\`,
+		},
+	}
+	for _, test := range tests {
+		rs := strings.NewReader(test.in)
+		re, err := Compile(rs, Options{Delimited: true})
+		if err != nil {
+			t.Errorf("%s re1.Compile(%q, Options{Delimited: true}) %v",
+				test.name, test.in, err)
+		} else if str := re.String(); str != test.out {
+			t.Errorf("%s (%q).String()=%q, want %q",
+				test.name, test.in, str, test.out)
+		}
+	}
+}
+
+func TestDelimitedString(t *testing.T) {
+	tests := []struct {
+		name    string
+		in, out string
+		delim   rune
+	}{
+		{
+			name:  "empty",
+			in:    "",
+			delim: '/',
+			out:   "//",
+		},
+		{
+			name:  "simple",
+			in:    `abc`,
+			delim: '/',
+			out:   `/abc/`,
+		},
+		{
+			name:  "escape delimiter",
+			in:    `ab/c`,
+			delim: '/',
+			out:   `/ab\/c/`,
+		},
+		{
+			name:  "already escaped delimiter",
+			in:    `ab\/c`,
+			delim: '/',
+			out:   `/ab\/c/`,
+		},
+		{
+			name:  "charclass delimiter",
+			in:    `ab[/]c`,
+			delim: '/',
+			out:   `/ab[/]c/`,
+		},
+		{
+			name:  "escape meta delimiter",
+			in:    `abc*`,
+			delim: '*',
+			out:   `*abc\**`,
+		},
+		{
+			name:  "already escaped meta delimiter",
+			in:    `a\*`,
+			delim: '*',
+			out:   `*a[*]*`,
+		},
+		{
+			name:  "charclass meta delimiter",
+			in:    `abc\*`,
+			delim: '*',
+			out:   `*abc[*]*`,
+		},
+		{
+			name:  "obrace delimiter",
+			in:    `a[xyz]b`,
+			delim: '[',
+			out:   `[a\[xyz]b[`,
+		},
+		{
+			name:  "obrace delimiter add charclass",
+			in:    `a\[b`,
+			delim: '[',
+			out:   `[a[[]b[`,
+		},
+		{
+			name:  "trailing escape",
+			in:    `abc\`,
+			delim: '/',
+			out:   `/abc\\/`,
+		},
+		{
+			name:  "only escape",
+			in:    `\`,
+			delim: '/',
+			out:   `/\\/`,
+		},
+		{
+			name:  "escape in charclass",
+			in:    `[\]]`,
+			delim: '/',
+			out:   `/[\]]/`,
+		},
+		{
+			name:  "escaped delim in charclass",
+			in:    `[\/]`,
+			delim: '/',
+			out:   `/[\/]/`,
+		},
+		{
+			name:  "double escape",
+			in:    `\\[\\]`,
+			delim: '/',
+			out:   `/\\[\\]/`,
+		},
+		{
+			name:  "double escape before delimiter",
+			in:    `\\/`,
+			delim: '/',
+			out:   `/\\\//`,
+		},
+	}
+	for _, test := range tests {
+		rs := strings.NewReader(test.in)
+		re, err := Compile(rs, Options{})
+		if err != nil {
+			t.Errorf("%s re1.Compile(%q, Options{}) %v", test.name, test.in, err)
+		} else if str := re.DelimitedString(test.delim); str != test.out {
+			t.Errorf("%s (%q).DelimitedString(%q)=%q, want %q",
+				test.name, test.in, test.delim, str, test.out)
 		}
 	}
 }


### PR DESCRIPTION
This pushes the re1.Compile error handling up to the user in various cases.