### PR TITLE
Fix a golint complaint.

### DIFF
--- a/edit/addr.go
+++ b/edit/addr.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// All is the address of the entire buffer: 0,$.
-	All Address = Line(0).To(End)
+	All = Line(0).To(End)
 	// Dot is the address of the Editor's dot.
 	Dot SimpleAddress = simpleAddr{dotAddr{}}
 	// End is the address of the empty string at the end of the buffer.

--- a/gok.sh
+++ b/gok.sh
@@ -24,7 +24,6 @@ go test -test.timeout=1s ./... 2>&1 > $o || fail
 
 echo Linting
 golint .\
-	| grep -v 'should omit type Address'\
 	| grep -v 'should omit type SimpleAddress'\
 	> $o 2>&1
 # Silly: diff the grepped golint output with empty.


### PR DESCRIPTION
No need to specify Address in the declaration of All, it will be correctly inferred.
We still need to specify SimpleAddress for Dot and End, or else they will be inferred as the unexported type simpleAddr.