### PR TITLE
Delimiter fixes

### DIFF
--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -68,10 +68,10 @@ func benchmarkRegexp(b *testing.B, re string, n int) {
 }
 
 const (
-	easy0  = "/ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
-	easy1  = "/A[AB]B[BC]C[CD]D[DE]E[EF]F[FG]G[GH]H[HI]I[IJ]J$"
-	medium = "/[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
-	hard   = "/[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	easy0  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	easy1  = "A[AB]B[BC]C[CD]D[DE]E[EF]F[FG]G[GH]H[HI]I[IJ]J$"
+	medium = "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+	hard   = "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
 )
 
 func BenchmarkRegexpEasy0x32(b *testing.B)  { benchmarkRegexp(b, easy0, 32<<0) }

--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -135,11 +135,11 @@ func TestLineAddress(t *testing.T) {
 
 func TestRegexpAddress(t *testing.T) {
 	tests := []addressTest{
-		{text: "Hello, 世界!", addr: Regexp("/"), want: pt(0)},
-		{text: "Hello, 世界!", addr: Regexp("/H"), want: rng(0, 1)},
-		{text: "Hello, 世界!", addr: Regexp("/."), want: rng(0, 1)},
-		{text: "Hello, 世界!", addr: Regexp("/世界"), want: rng(7, 9)},
-		{text: "Hello, 世界!", addr: Regexp("/[^!]+"), want: rng(0, 9)},
+		{text: "Hello, 世界!", addr: Regexp(""), want: pt(0)},
+		{text: "Hello, 世界!", addr: Regexp("H"), want: rng(0, 1)},
+		{text: "Hello, 世界!", addr: Regexp("."), want: rng(0, 1)},
+		{text: "Hello, 世界!", addr: Regexp("世界"), want: rng(7, 9)},
+		{text: "Hello, 世界!", addr: Regexp("[^!]+"), want: rng(0, 9)},
 
 		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?"), want: pt(10)},
 		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?!"), want: rng(9, 10)},
@@ -147,15 +147,15 @@ func TestRegexpAddress(t *testing.T) {
 		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?H"), want: rng(0, 1)},
 		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("?[^!]+"), want: rng(0, 9)},
 
-		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("/H").reverse(), want: rng(0, 1)},
+		{text: "Hello, 世界!", dot: pt(10), addr: Regexp("H").reverse(), want: rng(0, 1)},
 		{text: "Hello, 世界!", addr: Regexp("?H").reverse(), want: rng(0, 1)},
 
 		// Wrap.
 		{text: "Hello, 世界!", addr: Regexp("?世界"), want: rng(7, 9)},
-		{text: "Hello, 世界!", dot: pt(8), addr: Regexp("/世界"), want: rng(7, 9)},
+		{text: "Hello, 世界!", dot: pt(8), addr: Regexp("世界"), want: rng(7, 9)},
 
-		{text: "", addr: Regexp("/()"), err: "operand"},
-		{text: "Hello, 世界!", addr: Regexp("/☺"), err: "no match"},
+		{text: "", addr: Regexp("()"), err: "operand"},
+		{text: "Hello, 世界!", addr: Regexp("☺"), err: "no match"},
 		{text: "Hello, 世界!", addr: Regexp("?☺"), err: "no match"},
 	}
 	for _, test := range tests {
@@ -168,20 +168,15 @@ func TestRegexpString(t *testing.T) {
 	tests := []struct {
 		re, want string
 	}{
-		{"", "//"},
-		{"/", "//"},
-		{"☺", "☺☺"},
-		{"//", "//"},
-		{"☺☺", "☺☺"},
-		{`/\/`, `/\//`},
-		{`☺\☺`, `☺\☺☺`},
-		{"/abc", "/abc/"},
-		{"/abc/", "/abc/"},
-		{"☺abc", "☺abc☺"},
-		{"☺abc☺", "☺abc☺"},
-		{"/abc", "/abc/"},
-		{`/abc\/`, `/abc\//`},
-		{`☺abc\☺`, `☺abc\☺☺`},
+		{``, `//`},
+		{`abc`, `/abc/`},
+		{`ab/c`, `/ab\/c/`},
+		{`ab[/]c`, `/ab[/]c/`},
+		{`?`, `??`},
+		{`?abc`, `?abc?`},
+		{`?abc?`, `?abc?`},
+		{`?ab\?c?`, `?ab\?c?`},
+		{`?ab[?]c?`, `?ab[?]c?`},
 	}
 	for _, test := range tests {
 		re := Regexp(test.re)
@@ -216,7 +211,7 @@ func TestMinusAddress(t *testing.T) {
 		{text: "abc", addr: Rune(2).Minus(Rune(-1)), want: pt(3)},
 		{text: "abc\ndef", addr: Line(1).Minus(Line(1)), want: pt(0)},
 		{text: "abc\ndef", dot: rng(1, 6), addr: Dot.Minus(Line(1)).Plus(Line(1)), want: rng(0, 4)},
-		{text: "abc", dot: pt(3), addr: Dot.Minus(Regexp("/aa?/")), want: rng(0, 1)},
+		{text: "abc", dot: pt(3), addr: Dot.Minus(Regexp("aa?")), want: rng(0, 1)},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -231,7 +226,7 @@ func TestToAddress(t *testing.T) {
 		{text: "abc\ndef", addr: Line(1).To(Line(2)), want: rng(0, 7)},
 		{
 			text: "abcabc",
-			addr: Regexp("/abc").To(Regexp("/b")),
+			addr: Regexp("abc").To(Regexp("b")),
 			want: rng(0, 2),
 		},
 		{
@@ -249,8 +244,8 @@ func TestToAddress(t *testing.T) {
 
 func TestThenAddress(t *testing.T) {
 	tests := []addressTest{
-		{text: "abcabc", addr: Regexp("/abc/").Then(Regexp("/b/")), want: rng(0, 5)},
-		{text: "abcabc", addr: Regexp("/abc/").Then(Dot.Plus(Rune(1))), want: rng(0, 4)},
+		{text: "abcabc", addr: Regexp("abc").Then(Regexp("b")), want: rng(0, 5)},
+		{text: "abcabc", addr: Regexp("abc").Then(Dot.Plus(Rune(1))), want: rng(0, 4)},
 		{text: "abcabc", addr: Line(0).Plus(Rune(1)).Then(Dot.Plus(Rune(1))), want: rng(1, 2)},
 		{text: "abcabc", addr: Line(0).To(Rune(1)).Then(Dot.Plus(Rune(1))), want: rng(0, 2)},
 	}
@@ -330,19 +325,19 @@ func TestAddr(t *testing.T) {
 		{a: " 1\t\n\txyz", left: "\txyz", want: Line(1)},
 		{a: strconv.FormatInt(math.MaxInt64, 10) + "0", err: "out of range"},
 
-		{a: "/", want: Regexp("/")},
-		{a: "//", want: Regexp("//")},
+		{a: "/", want: Regexp("")},
+		{a: "//", want: Regexp("")},
 		{a: "?", want: Regexp("?")},
-		{a: "??", want: Regexp("??")},
-		{a: "/abcdef", want: Regexp("/abcdef")},
-		{a: "/abc/def", left: "def", want: Regexp("/abc/")},
-		{a: "/abc def", want: Regexp("/abc def")},
-		{a: "/abc def\nxyz", left: "xyz", want: Regexp("/abc def/")},
+		{a: "??", want: Regexp("?")},
+		{a: "/abcdef", want: Regexp("abcdef")},
+		{a: "/abc/def", left: "def", want: Regexp("abc")},
+		{a: "/abc def", want: Regexp("abc def")},
+		{a: "/abc def\nxyz", left: "xyz", want: Regexp("abc def")},
 		{a: "?abcdef", want: Regexp("?abcdef")},
-		{a: "?abc?def", left: "def", want: Regexp("?abc?")},
+		{a: "?abc?def", left: "def", want: Regexp("?abc")},
 		{a: "?abc def", want: Regexp("?abc def")},
 		{a: " ?abc def", want: Regexp("?abc def")},
-		{a: "?abc def\nxyz", left: "xyz", want: Regexp("?abc def?")},
+		{a: "?abc def\nxyz", left: "xyz", want: Regexp("?abc def")},
 		{a: "/()", err: "operand"},
 
 		{a: "$", want: End},
@@ -381,10 +376,10 @@ func TestAddr(t *testing.T) {
 		{a: "+-", want: Dot.Plus(Line(1)).Minus(Line(1))},
 		{a: " + - ", want: Dot.Plus(Line(1)).Minus(Line(1))},
 		{a: " - + ", want: Dot.Minus(Line(1)).Plus(Line(1))},
-		{a: "/abc/+++---", want: Regexp("/abc/").Plus(Line(1)).Plus(Line(1)).Plus(Line(1)).Minus(Line(1)).Minus(Line(1)).Minus(Line(1))},
+		{a: "/abc/+++---", want: Regexp("abc").Plus(Line(1)).Plus(Line(1)).Plus(Line(1)).Minus(Line(1)).Minus(Line(1)).Minus(Line(1))},
 
-		{a: ".+/aa?/", want: Dot.Plus(Regexp("/aa?/"))},
-		{a: ".-/aa?/", want: Dot.Minus(Regexp("/aa?/"))},
+		{a: ".+/aa?/", want: Dot.Plus(Regexp("aa?"))},
+		{a: ".-/aa?/", want: Dot.Minus(Regexp("aa?"))},
 
 		{a: ",", want: Line(0).To(End)},
 		{a: ",xyz", left: "xyz", want: Line(0).To(End)},
@@ -416,9 +411,9 @@ func TestAddr(t *testing.T) {
 		// Implicit +.
 		{a: "1#2", want: Line(1).Plus(Rune(2))},
 		{a: "#2 1", want: Rune(2).Plus(Line(1))},
-		{a: "1/abc", want: Line(1).Plus(Regexp("/abc"))},
-		{a: "/abc/1", want: Regexp("/abc/").Plus(Line(1))},
-		{a: "?abc?1", want: Regexp("?abc?").Plus(Line(1))},
+		{a: "1/abc", want: Line(1).Plus(Regexp("abc"))},
+		{a: "/abc/1", want: Regexp("abc").Plus(Line(1))},
+		{a: "?abc?1", want: Regexp("?abc").Plus(Line(1))},
 		{a: "$?abc", want: End.Plus(Regexp("?abc"))},
 	}
 	for _, test := range tests {
@@ -426,13 +421,12 @@ func TestAddr(t *testing.T) {
 		a, err := Addr(rs)
 		if test.err != "" {
 			if !regexp.MustCompile(test.err).MatchString(err.Error()) {
-				t.Errorf(`Addr(%q)=%q,%q, want %q,%q`,
-					test.a, a, err, test.want, test.err)
+				t.Errorf(`Addr(%q)=%q,%v, want %q,%q`, test.a, a, err, test.want, test.err)
 			}
 			continue
 		}
 		if err != nil || !reflect.DeepEqual(a, test.want) {
-			t.Errorf(`Addr(%q)=%q,%q, want %q,%q`, test.a, a, err, test.want, test.err)
+			t.Errorf(`Addr(%q)=%q,%v, want %q,%q`, test.a, a, err, test.want, test.err)
 			continue
 		}
 		left, err := ioutil.ReadAll(rs)
@@ -514,8 +508,7 @@ func TestAddressString(t *testing.T) {
 		{addr: Line(-100), want: Dot.Minus(Line(100))},
 		{addr: Mark('a')},
 		{addr: Mark('z')},
-		{addr: Regexp("/☺☹")},
-		{addr: Regexp("/☺☹/")},
+		{addr: Regexp("☺☹")},
 		{addr: Regexp("?☺☹")},
 		{addr: Regexp("?☺☹?")},
 		{addr: Dot.Plus(Line(1))},
@@ -523,7 +516,7 @@ func TestAddressString(t *testing.T) {
 		{addr: Dot.Minus(Line(1)).Plus(Line(1))},
 		{addr: Rune(1).To(Rune(2))},
 		{addr: Rune(1).Then(Rune(2))},
-		{addr: Regexp("/func").Plus(Regexp(`/\(`))},
+		{addr: Regexp("func").Plus(Regexp(`\(`))},
 	}
 	for _, test := range tests {
 		if test.want == nil {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -161,16 +161,30 @@ type change struct {
 // Change returns an Edit
 // that changes the string at a to str,
 // and sets dot to the changed runes.
+//
+// The rune \ in str is interpreted as an escape.
+// \n is a literal newline.
+// All other escaped runes are the rune themselves.
+// For example,
+// 	\n is a literal newline
+// 	\\ is \
+// 	\a is a
 func Change(a Address, str string) Edit { return change{a: a, op: 'c', str: str} }
 
 // Append returns an Edit
 // that appends str after the string at a,
 // and sets dot to the appended runes.
+//
+// The rune \ in str is interpreted as an escape,
+// as described for the Change function.
 func Append(a Address, str string) Edit { return change{a: a, op: 'a', str: str} }
 
 // Insert returns an Edit
 // that inserts str before the string at a,
 // and sets dot to the inserted runes.
+//
+// The rune \ in str is interpreted as an escape,
+// as described for the Change function.
 func Insert(a Address, str string) Edit { return change{a: a, op: 'i', str: str} }
 
 // Delete returns an Edit
@@ -179,7 +193,9 @@ func Insert(a Address, str string) Edit { return change{a: a, op: 'i', str: str}
 // that was deleted.
 func Delete(a Address) Edit { return change{a: a, op: 'd'} }
 
-func (e change) String() string { return e.a.String() + string(e.op) + escape(e.str) }
+func (e change) String() string {
+	return e.a.String() + string(e.op) + "/" + escape('/', e.str) + "/"
+}
 
 func (e change) do(ed *Editor, _ io.Writer) (addr, error) {
 	switch e.op {
@@ -192,31 +208,8 @@ func (e change) do(ed *Editor, _ io.Writer) (addr, error) {
 	if err != nil {
 		return addr{}, err
 	}
-	return at, pend(ed, at, runes.StringReader(e.str))
-}
-
-func escape(str string) string {
-	if r, _ := utf8.DecodeLastRuneInString(str); r == '\n' {
-		// Use multi-line format.
-		return "\n" + str + ".\n"
-	}
-
-	const (
-		delim = '/'
-		esc   = '\\'
-	)
-	es := []rune{delim}
-	for _, r := range str {
-		switch r {
-		case '\n':
-			es = append(es, esc, 'n')
-		case delim:
-			es = append(es, esc, r)
-		default:
-			es = append(es, r)
-		}
-	}
-	return string(append(es, delim))
+	unesc := unescape(e.str, nil)
+	return at, pend(ed, at, runes.StringReader(unesc))
 }
 
 type move struct {
@@ -396,15 +389,27 @@ type Substitute struct {
 	// After performing the edit, Dot is set the modified address A.
 	A Address
 	// RE is the regular expression to match.
-	// It is compiled with re1.Options{Delimited: true}.
+	//
+	// The regular expression must use the syntax of the re1 package:
+	// http://godoc.org/github.com/eaburns/T/re1.
+	// It is compiled with re1.Options{}
+	// when the edit is computed on a buffer.
+	// Compilation errors will not be returned until that time.
+	// If the regexp is malformed, the string representation of the Edit
+	// will be similarly malformed.
 	RE string
 	// With is the runes with which to replace each match.
-	// Within With, a backslash followed by a digit d
-	// stands for the string that matched the d-th subexpression.
-	// Subexpression 0 is the entire match.
-	// It is an error if such a subexpression contains
-	// more than MaxRunes runes.
+	// The rune \ in str is interpreted as an escape.
 	// \n is a literal newline.
+	// \ followed by a digit d stands for d-th subexpression match.
+	// All other escaped runes are the rune themselves.
+	// For example,
+	// 	\n is a literal newline
+	// 	\1 is the first subexpression match.
+	// 	\\ is \
+	// 	\a is a
+	// It is an error if such a subexpression match used within With
+	// contains more than MaxRunes runes.
 	With string
 	// Global is whether to replace all matches, or just one.
 	// If Global is false, only one match is replaced.
@@ -445,7 +450,7 @@ func (e Substitute) String() string {
 	if e.RE == "" {
 		e.RE = "/"
 	}
-	s += withTrailingDelim(e.RE) + e.With
+	s += withTrailingDelim(e.RE) + escape('/', e.With)
 	if e.Global {
 		delim, _ := utf8.DecodeRuneInString(e.RE)
 		s += string(delim) + "g"
@@ -485,15 +490,15 @@ func subSingle(ed *Editor, at addr, re *re1.Regexp, with string, n int) ([][2]in
 	if err != nil || m == nil {
 		return m, err
 	}
-	rs, err := replRunes(ed, m, with)
+	repl, err := replRunes(ed, m, with)
 	if err != nil {
 		return nil, err
 	}
 	at = addr{m[0][0], m[0][1]}
-	return m, pend(ed, at, runes.SliceReader(rs))
+	return m, pend(ed, at, runes.StringReader(repl))
 }
 
-// nthMatch skips past the first n-1 matches of the regular expression.
+// NthMatch skips past the first n-1 matches of the regular expression.
 // If n ≤ 0, the first match is returned.
 func nthMatch(ed *Editor, at addr, re *re1.Regexp, n int) ([][2]int64, error) {
 	var err error
@@ -512,48 +517,21 @@ func nthMatch(ed *Editor, at addr, re *re1.Regexp, n int) ([][2]int64, error) {
 }
 
 // ReplRunes returns the runes that replace a matched regexp.
-func replRunes(ed *Editor, m [][2]int64, with string) ([]rune, error) {
-	var rs []rune
-	repl := []rune(with)
-	for i := 0; i < len(repl); i++ {
-		d := escDigit(repl[i:])
-		if d < 0 {
-			rs = append(rs, repl[i])
-			continue
+func replRunes(ed *Editor, m [][2]int64, with string) (string, error) {
+	var err error
+	repl := unescape(with, func(i int) (match []rune) {
+		if err != nil || i < 0 || i >= len(m) {
+			return nil
 		}
-		sub, err := subExprMatch(ed, m, d)
-		if err != nil {
-			return nil, err
+		n := m[i][1] - m[i][0]
+		if n > MaxRunes {
+			err = errors.New("subexpression too big")
+			return nil
 		}
-		rs = append(rs, sub...)
-		i++
-	}
-	return rs, nil
-}
-
-// EscDigit returns the digit from \[0-9]
-// or -1 if the text does not represent an escaped digit.
-func escDigit(sub []rune) int {
-	if len(sub) >= 2 && sub[0] == '\\' && unicode.IsDigit(sub[1]) {
-		return int(sub[1] - '0')
-	}
-	return -1
-}
-
-// SubExprMatch returns the runes of a matched subexpression.
-func subExprMatch(ed *Editor, m [][2]int64, i int) ([]rune, error) {
-	if i < 0 || i >= len(m) {
-		return []rune{}, nil
-	}
-	n := m[i][1] - m[i][0]
-	if n > MaxRunes {
-		return nil, errors.New("subexpression too big")
-	}
-	rs, err := ed.buf.runes.Read(int(n), m[i][0])
-	if err != nil {
-		return nil, err
-	}
-	return rs, nil
+		match, err = ed.buf.runes.Read(int(n), m[i][0])
+		return match
+	})
+	return repl, err
 }
 
 type runeSlice struct {
@@ -1088,7 +1066,6 @@ func parseLines(rs io.RuneScanner) (string, error) {
 // raw newline (rune 0xA),
 // or the end of input.
 // A delimiter preceeded by \ is escaped and is non-terminating.
-// The letter n preceeded by \ is a newline literal.
 func parseDelimited(delim rune, rs io.RuneScanner) (string, error) {
 	var s []rune
 	var esc bool
@@ -1099,23 +1076,68 @@ func parseDelimited(delim rune, rs io.RuneScanner) (string, error) {
 		case err != nil:
 			return "", err
 		case esc && r == delim:
-			s = append(s, delim)
+			s = append(s[:len(s)-1], r)
+			esc = false
+		case esc && r == 'n':
+			s = append(s[:len(s)-1], '\n')
 			esc = false
 		case r == delim || r == '\n':
 			return string(s), nil
-		case !esc && r == '\\':
-			esc = true
-		case esc && r == 'n':
-			s = append(s, '\n')
-			esc = false
 		default:
-			if esc {
-				s = append(s, '\\')
-			}
 			s = append(s, r)
-			esc = false
+			esc = !esc && r == '\\'
 		}
 	}
+}
+
+// Escape returns str with all unescaped delimiters and newlines escaped.
+func escape(delim rune, str string) string {
+	var s []rune
+	var esc bool
+	for _, r := range str {
+		if !esc && r == delim {
+			s = append(s, '\\')
+		}
+		if r == '\n' {
+			if !esc {
+				s = append(s, '\\')
+			}
+			r = 'n'
+		}
+		s = append(s, r)
+		esc = !esc && r == '\\'
+	}
+	if esc {
+		s = append(s, '\\')
+	}
+	return string(s)
+}
+
+// Unescape returns str with all escapes removed.
+// \n is interpreted as a literal newline.
+// If lookup is non-nil, escaped digits are replaced with the result of lookup.
+func unescape(str string, lookup func(int) []rune) string {
+	var s []rune
+	var esc bool
+	for _, r := range str {
+		switch {
+		case !esc && r == '\\':
+			esc = true
+			continue
+		case esc && lookup != nil && unicode.IsDigit(r):
+			s = append(s, lookup(int(r-'0'))...)
+		case esc && r == 'n':
+			r = '\n'
+			fallthrough
+		default:
+			s = append(s, r)
+		}
+		esc = false
+	}
+	if esc {
+		s = append(s, '\\')
+	}
+	return string(s)
 }
 
 func parseMarkRune(rs io.RuneScanner) (rune, error) {

--- a/edit/edit_example_test.go
+++ b/edit/edit_example_test.go
@@ -42,7 +42,7 @@ func ExampleAddress() {
 
 		// Regular expressions.
 		parseAddr("/Hello/"),
-		Regexp("/Hello/"),
+		Regexp("Hello"),
 		// A regular expression, searching in reverse.
 		Regexp("?Hello?"),
 
@@ -56,9 +56,9 @@ func ExampleAddress() {
 
 		// Addresses relative to other addresses.
 		parseAddr("#0+/l/,#5"),
-		Rune(0).Plus(Regexp("/l")).To(Rune(5)),
+		Rune(0).Plus(Regexp("l")).To(Rune(5)),
 		parseAddr("$-/l/,#5"),
-		End.Minus(Regexp("/l")).To(Rune(5)),
+		End.Minus(Regexp("l")).To(Rune(5)),
 	}
 
 	// Print the contents of the editor at each address to os.Stdout.
@@ -117,7 +117,7 @@ func ExampleEdit() {
 		// Here is the same Edit built with a funciton.
 		Print(All),
 		// This prints a different address.
-		Print(Regexp("/,").Plus(Rune(1)).To(End)),
+		Print(Regexp(",").Plus(Rune(1)).To(End)),
 
 		// c changes the buffer at a given address preceeding it.
 		// After this change, the buffer will contain: "Hello, 世界!\n"
@@ -126,7 +126,7 @@ func ExampleEdit() {
 
 		// Or you can do it with functions.
 		// After this change, the buffer will contain: "Hello, World!\n" again.
-		Change(Regexp("/世界"), "World"),
+		Change(Regexp("世界"), "World"),
 		Print(All),
 
 		// There is infinite Undo…
@@ -140,7 +140,7 @@ func ExampleEdit() {
 
 		// You can also edit with regexp substitution.
 		Change(All, "...===...\n"),
-		Sub(All, "/(=+)/", `---\1---`),
+		Sub(All, "(=+)", `---\1---`),
 		Print(All),
 		parseEd(`,s/\./_/g`),
 		Print(All),

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -184,13 +184,13 @@ func TestMoveEdit(t *testing.T) {
 		{e: Move(Rune(1), Rune(2)), err: "address out of range"},
 		{init: "a", e: Move(Rune(1), Rune(2)), err: "address out of range"},
 
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(0)), want: "abc", dot: addr{0, 3}},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(1)), err: "overlap"},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(2)), err: "overlap"},
-		{init: "abc", e: Move(Regexp("/abc/"), Rune(3)), want: "abc", dot: addr{0, 3}},
-		{init: "abcdef", e: Move(Regexp("/abc/"), End), want: "defabc", dot: addr{3, 6}},
-		{init: "abcdef", e: Move(Regexp("/def/"), Line(0)), want: "defabc", dot: addr{0, 3}},
-		{init: "abc\ndef\nghi", e: Move(Regexp("/def/"), Line(3)), want: "abc\n\nghidef", dot: addr{8, 11}},
+		{init: "abc", e: Move(Regexp("abc"), Rune(0)), want: "abc", dot: addr{0, 3}},
+		{init: "abc", e: Move(Regexp("abc"), Rune(1)), err: "overlap"},
+		{init: "abc", e: Move(Regexp("abc"), Rune(2)), err: "overlap"},
+		{init: "abc", e: Move(Regexp("abc"), Rune(3)), want: "abc", dot: addr{0, 3}},
+		{init: "abcdef", e: Move(Regexp("abc"), End), want: "defabc", dot: addr{3, 6}},
+		{init: "abcdef", e: Move(Regexp("def"), Line(0)), want: "defabc", dot: addr{0, 3}},
+		{init: "abc\ndef\nghi", e: Move(Regexp("def"), Line(3)), want: "abc\n\nghidef", dot: addr{8, 11}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -202,11 +202,11 @@ func TestCopyEdit(t *testing.T) {
 		{e: Copy(Rune(1), Rune(2)), err: "address out of range"},
 		{init: "a", e: Copy(Rune(1), Rune(3)), err: "address out of range"},
 
-		{init: "abc", e: Copy(Regexp("/abc/"), End), want: "abcabc", dot: addr{3, 6}},
-		{init: "abc", e: Copy(Regexp("/abc/"), Line(0)), want: "abcabc", dot: addr{0, 3}},
-		{init: "abc", e: Copy(Regexp("/abc/"), Rune(1)), want: "aabcbc", dot: addr{1, 4}},
-		{init: "abcdef", e: Copy(Regexp("/abc/"), Rune(4)), want: "abcdabcef", dot: addr{4, 7}},
-		{init: "abc\ndef\nghi", e: Copy(Regexp("/def/"), Line(1)), want: "abc\ndefdef\nghi", dot: addr{4, 7}},
+		{init: "abc", e: Copy(Regexp("abc"), End), want: "abcabc", dot: addr{3, 6}},
+		{init: "abc", e: Copy(Regexp("abc"), Line(0)), want: "abcabc", dot: addr{0, 3}},
+		{init: "abc", e: Copy(Regexp("abc"), Rune(1)), want: "aabcbc", dot: addr{1, 4}},
+		{init: "abcdef", e: Copy(Regexp("abc"), Rune(4)), want: "abcdabcef", dot: addr{4, 7}},
+		{init: "abc\ndef\nghi", e: Copy(Regexp("def"), Line(1)), want: "abc\ndefdef\nghi", dot: addr{4, 7}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -225,7 +225,7 @@ func TestSetEdit(t *testing.T) {
 		{init: s, want: s, e: Set(All, '\t'), dot: addr{0, 10}},
 		{init: s, want: s, e: Set(All, 'a'), marks: map[rune]addr{'a': addr{0, 10}}},
 		{init: s, want: s, e: Set(All, 'α'), marks: map[rune]addr{'α': addr{0, 10}}},
-		{init: s, want: s, e: Set(Regexp("/Hello"), 'a'), marks: map[rune]addr{'a': addr{0, 5}}},
+		{init: s, want: s, e: Set(Regexp("Hello"), 'a'), marks: map[rune]addr{'a': addr{0, 5}}},
 		{init: s, want: s, e: Set(Line(0), 'z'), marks: map[rune]addr{'z': addr{0, 0}}},
 		{init: s, want: s, e: Set(End, 'm'), marks: map[rune]addr{'m': addr{10, 10}}},
 	}
@@ -242,9 +242,9 @@ func TestPrintEdit(t *testing.T) {
 		{e: Print(All), print: "", dot: addr{0, 0}},
 		{init: s, want: s, e: Print(All), print: s, dot: addr{0, 10}},
 		{init: s, want: s, e: Print(End), print: "", dot: addr{10, 10}},
-		{init: s, want: s, e: Print(Regexp("/H/")), print: "H", dot: addr{0, 1}},
-		{init: s, want: s, e: Print(Regexp("/Hello/")), print: "Hello", dot: addr{0, 5}},
-		{init: s, want: s, e: Print(Regexp("/世界/")), print: "世界", dot: addr{7, 9}},
+		{init: s, want: s, e: Print(Regexp("H")), print: "H", dot: addr{0, 1}},
+		{init: s, want: s, e: Print(Regexp("Hello")), print: "Hello", dot: addr{0, 5}},
+		{init: s, want: s, e: Print(Regexp("世界")), print: "世界", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -263,8 +263,8 @@ func TestWhereEdit(t *testing.T) {
 		{init: s, want: s, e: Where(End), print: "#10", dot: addr{10, 10}},
 		{init: s, want: s, e: Where(Line(1)), print: "#0,#6", dot: addr{0, 6}},
 		{init: s, want: s, e: Where(Line(2)), print: "#6,#10", dot: addr{6, 10}},
-		{init: s, want: s, e: Where(Regexp("/Hello")), print: "#0,#5", dot: addr{0, 5}},
-		{init: s, want: s, e: Where(Regexp("/世界")), print: "#7,#9", dot: addr{7, 9}},
+		{init: s, want: s, e: Where(Regexp("Hello")), print: "#0,#5", dot: addr{0, 5}},
+		{init: s, want: s, e: Where(Regexp("世界")), print: "#7,#9", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -283,8 +283,8 @@ func TestWhereLinesEdit(t *testing.T) {
 		{init: s, want: s, e: WhereLine(End), print: "2", dot: addr{10, 10}},
 		{init: s, want: s, e: WhereLine(Line(1)), print: "1", dot: addr{0, 6}},
 		{init: s, want: s, e: WhereLine(Line(2)), print: "2", dot: addr{6, 10}},
-		{init: s, want: s, e: WhereLine(Regexp("/Hello")), print: "1", dot: addr{0, 5}},
-		{init: s, want: s, e: WhereLine(Regexp("/世界")), print: "2", dot: addr{7, 9}},
+		{init: s, want: s, e: WhereLine(Regexp("Hello")), print: "1", dot: addr{0, 5}},
+		{init: s, want: s, e: WhereLine(Regexp("世界")), print: "2", dot: addr{7, 9}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -293,8 +293,8 @@ func TestWhereLinesEdit(t *testing.T) {
 
 func TestSubstituteEdit(t *testing.T) {
 	tests := []eTest{
-		{e: Sub(Rune(1), "/abc", "xyz"), err: "address out of range"},
-		{e: Substitute{A: All, RE: "/*/"}, err: "missing operand"},
+		{e: Sub(Rune(1), "abc", "xyz"), err: "address out of range"},
+		{e: Substitute{A: All, RE: "*"}, err: "missing operand"},
 
 		{
 			init: "世界!",
@@ -303,131 +303,131 @@ func TestSubstituteEdit(t *testing.T) {
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/.*/", With: "", Global: true},
+			e:    Substitute{A: All, RE: ".*", With: "", Global: true},
 			want: "", dot: addr{0, 0},
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/世界/", With: "World"},
+			e:    Substitute{A: All, RE: "世界", With: "World"},
 			want: "Hello, World!", dot: addr{0, 13},
 		},
 		{
 			init: "Hello, 世界!",
-			e:    Substitute{A: All, RE: "/(.)/", With: `\1-`, Global: true},
+			e:    Substitute{A: All, RE: "(.)", With: `\1-`, Global: true},
 			want: "H-e-l-l-o-,- -世-界-!-", dot: addr{0, 20},
 		},
 		{
 			init: "abcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg"},
+			e:    Substitute{A: All, RE: "abc", With: "defg"},
 			want: "defgabc", dot: addr{0, 7},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: All, RE: "abc", With: "defg", Global: true},
 			want: "defgdefgdefg", dot: addr{0, 12},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: Regexp("/abcabc/"), RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: Regexp("abcabc"), RE: "abc", With: "defg", Global: true},
 			want: "defgdefgabc", dot: addr{0, 8},
 		},
 		{
 			init: "abc abc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg"},
+			e:    Substitute{A: All, RE: "abc", With: "defg"},
 			want: "defg abc", dot: addr{0, 8},
 		},
 		{
 			init: "abc abc",
-			e:    Substitute{A: All, RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: All, RE: "abc", With: "defg", Global: true},
 			want: "defg defg", dot: addr{0, 9},
 		},
 		{
 			init: "abc abc abc",
-			e:    Substitute{A: Regexp("/abc abc/"), RE: "/abc/", With: "defg", Global: true},
+			e:    Substitute{A: Regexp("abc abc"), RE: "abc", With: "defg", Global: true},
 			want: "defg defg abc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "de"},
+			e:    Substitute{A: All, RE: "abc", With: "de"},
 			want: "deabc", dot: addr{0, 5},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "de", Global: true},
+			e:    Substitute{A: All, RE: "abc", With: "de", Global: true},
 			want: "dedede", dot: addr{0, 6},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: Regexp("/abcabc/"), RE: "/abc/", With: "de", Global: true},
+			e:    Substitute{A: Regexp("abcabc"), RE: "abc", With: "de", Global: true},
 			want: "dedeabc", dot: addr{0, 4},
 		},
 		{
 			init: "func f()",
-			e:    Substitute{A: All, RE: `/func (.*)\(\)/`, With: `func (T) \1()`, Global: true},
+			e:    Substitute{A: All, RE: `func (.*)\(\)`, With: `func (T) \1()`, Global: true},
 			want: "func (T) f()", dot: addr{0, 12},
 		},
 		{
 			init: "abcdefghi",
-			e:    Substitute{A: All, RE: "/(abc)(def)(ghi)/", With: `\0 \3 \2 \1`},
+			e:    Substitute{A: All, RE: "(abc)(def)(ghi)", With: `\0 \3 \2 \1`},
 			want: "abcdefghi ghi def abc", dot: addr{0, 21},
 		},
 		{
 			init: "...===...",
-			e:    Substitute{A: All, RE: "/(=*)/", With: `---\1---`},
+			e:    Substitute{A: All, RE: "(=*)", With: `---\1---`},
 			want: "------...===...", dot: addr{0, 15},
 		},
 		{
 			init: "...===...",
-			e:    Substitute{A: All, RE: "/(=+)/", With: `---\1---`},
+			e:    Substitute{A: All, RE: "(=+)", With: `---\1---`},
 			want: "...---===---...", dot: addr{0, 15},
 		},
 		{
 			init: "abc",
-			e:    Substitute{A: All, RE: "/abc/", With: `\1`},
+			e:    Substitute{A: All, RE: "abc", With: `\1`},
 			want: "", dot: addr{0, 0},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 0},
+			e:    Substitute{A: All, RE: "abc", With: "def", From: 0},
 			want: "defabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 1},
+			e:    Substitute{A: All, RE: "abc", With: "def", From: 1},
 			want: "defabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 2},
+			e:    Substitute{A: All, RE: "abc", With: "def", From: 2},
 			want: "abcdefabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", Global: true, From: 2},
+			e:    Substitute{A: All, RE: "abc", With: "def", Global: true, From: 2},
 			want: "abcdefdef", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/notpresent/", With: "def", From: 4},
+			e:    Substitute{A: All, RE: "notpresent", With: "def", From: 4},
 			want: "abcabcabc", dot: addr{0, 9},
 		},
 		{
 			init: "abcabcabc",
-			e:    Substitute{A: All, RE: "/abc/", With: "def", From: 4},
+			e:    Substitute{A: All, RE: "abc", With: "def", From: 4},
 			want: "abcabcabc", dot: addr{0, 9},
 		},
 
 		// Test escaping.
-		{init: "a", e: Sub(All, "/a/", `/`), want: `/`, dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", `\`), want: `\`, dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", `\0`), want: `a`, dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", `\\0`), want: `\0`, dot: addr{0, 2}},
-		{init: "a", e: Sub(All, "/a/", "\n"), want: "\n", dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", `\n`), want: "\n", dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", "\\\n"), want: "\n", dot: addr{0, 1}},
-		{init: "a", e: Sub(All, "/a/", `\\n`), want: `\n`, dot: addr{0, 2}},
+		{init: "a", e: Sub(All, "a", `/`), want: `/`, dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `\`), want: `\`, dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `\0`), want: `a`, dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `\\0`), want: `\0`, dot: addr{0, 2}},
+		{init: "a", e: Sub(All, "a", "\n"), want: "\n", dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `\n`), want: "\n", dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", "\\\n"), want: "\n", dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `\\n`), want: `\n`, dot: addr{0, 2}},
 
-		{init: "a", e: Sub(All, "/a/", `/`), want: `/`, dot: addr{0, 1}},
+		{init: "a", e: Sub(All, "a", `/`), want: `/`, dot: addr{0, 1}},
 	}
 	for _, test := range tests {
 		test.run(t)
@@ -713,7 +713,7 @@ func TestUndoEdit(t *testing.T) {
 			name: "multi-change undo",
 			init: []Edit{
 				Append(End, "a.a.a"),
-				SubGlobal(All, "/[.]/", "z"),
+				SubGlobal(All, "[.]", "z"),
 			},
 			e:     Undo(1),
 			want:  "a.a.a",
@@ -723,8 +723,8 @@ func TestUndoEdit(t *testing.T) {
 			name: "undo maintains marks",
 			init: []Edit{
 				Append(End, "abcXXX"),
-				Set(Regexp("/XXX"), 'm'),
-				Delete(Regexp("/b")),
+				Set(Regexp("XXX"), 'm'),
+				Delete(Regexp("b")),
 			},
 			e:    Undo(1),
 			want: "abcXXX",
@@ -799,7 +799,7 @@ func TestRedoEdit(t *testing.T) {
 			name: "multi-change redo",
 			init: []Edit{
 				Append(End, "a.a.a"),
-				SubGlobal(All, "/[.]/", "z"),
+				SubGlobal(All, "[.]", "z"),
 				Undo(1),
 			},
 			e:     Redo(1),
@@ -810,8 +810,8 @@ func TestRedoEdit(t *testing.T) {
 			name: "redo maintains marks",
 			init: []Edit{
 				Append(End, "abcXXX"),
-				Set(Regexp("/XXX"), 'm'),
-				Delete(Regexp("/b")),
+				Set(Regexp("XXX"), 'm'),
+				Delete(Regexp("b")),
 				Undo(1),
 			},
 			e:    Redo(1),
@@ -904,7 +904,7 @@ func TestEd(t *testing.T) {
 		{e: "#0+1", want: Set(Rune(0).Plus(Line(1)), '.')},
 		{e: " #0 + 1 ", want: Set(Rune(0).Plus(Line(1)), '.')},
 		{e: "#0+1\nc/abc", left: "c/abc", want: Set(Rune(0).Plus(Line(1)), '.')},
-		{e: "/abc\n1c/xyz", left: "1c/xyz", want: Set(Regexp("/abc/"), '.')},
+		{e: "/abc\n1c/xyz", left: "1c/xyz", want: Set(Regexp("abc"), '.')},
 
 		{e: "k", want: Set(Dot, '.')},
 		{e: " k ", want: Set(Dot, '.')},
@@ -982,8 +982,8 @@ func TestEd(t *testing.T) {
 		{e: "d  \nxyz", left: "xyz", want: Delete(Dot)},
 
 		{e: "m", want: Move(Dot, Dot)},
-		{e: "m/abc/", want: Move(Dot, Regexp("/abc/"))},
-		{e: "/abc/m/def/", want: Move(Regexp("/abc/"), Regexp("/def/"))},
+		{e: "m/abc/", want: Move(Dot, Regexp("abc"))},
+		{e: "/abc/m/def/", want: Move(Regexp("abc"), Regexp("def"))},
 		{e: "#1+1m$", want: Move(Rune(1).Plus(Line(1)), End)},
 		{e: " #1 + 1 m $", want: Move(Rune(1).Plus(Line(1)), End)},
 		{e: "1m$xyz", left: "xyz", want: Move(Line(1), End)},
@@ -991,8 +991,8 @@ func TestEd(t *testing.T) {
 		{e: "m" + strconv.FormatInt(math.MaxInt64, 10) + "0", err: "value out of range"},
 
 		{e: "t", want: Copy(Dot, Dot)},
-		{e: "t/abc/", want: Copy(Dot, Regexp("/abc/"))},
-		{e: "/abc/t/def/", want: Copy(Regexp("/abc/"), Regexp("/def/"))},
+		{e: "t/abc/", want: Copy(Dot, Regexp("abc"))},
+		{e: "/abc/t/def/", want: Copy(Regexp("abc"), Regexp("def"))},
 		{e: "#1+1t$", want: Copy(Rune(1).Plus(Line(1)), End)},
 		{e: " #1 + 1 t $", want: Copy(Rune(1).Plus(Line(1)), End)},
 		{e: "1t$xyz", left: "xyz", want: Copy(Line(1), End)},
@@ -1014,28 +1014,30 @@ func TestEd(t *testing.T) {
 		{e: "#1+1=#", want: Where(Rune(1).Plus(Line(1)))},
 		{e: " #1 + 1 =#", want: Where(Rune(1).Plus(Line(1)))},
 
-		{e: "s/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "s;a;b", want: Sub(Dot, ";a;", "b")},
-		{e: "s/a//", want: Sub(Dot, "/a/", "")},
-		{e: "s/a/\n/g", left: "/g", want: Sub(Dot, "/a/", "")},
-		{e: "s/(.*)/a\\1", want: Sub(Dot, "/(.*)/", "a\\1")},
-		{e: ".s/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "#1+1s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: "s/a/b/xyz", left: "xyz", want: Sub(Dot, "/a/", "b")},
-		{e: "s/a/b\nxyz", left: "xyz", want: Sub(Dot, "/a/", "b")},
-		{e: "s1/a/b", want: Sub(Dot, "/a/", "b")},
-		{e: "s/a/b/g", want: SubGlobal(Dot, "/a/", "b")},
-		{e: " #1 + 1 s/a/b/g", want: SubGlobal(Rune(1).Plus(Line(1)), "/a/", "b")},
-		{e: "s2/a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 2}},
-		{e: "s2;a;b", want: Substitute{A: Dot, RE: ";a;", With: "b", From: 2}},
-		{e: "s1000/a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 1000}},
-		{e: "s 2 /a/b", want: Substitute{A: Dot, RE: "/a/", With: "b", From: 2}},
-		{e: "s 1000 /a/b/g", want: Substitute{A: Dot, RE: "/a/", With: "b", Global: true, From: 1000}},
-		{e: "s/", err: "missing pattern"},
-		{e: "s//b", err: "missing pattern"},
-		{e: "s/\n/b", err: "missing pattern"},
+		{e: "s/a/b", want: Sub(Dot, "a", "b")},
+		{e: "s;a;b", want: Sub(Dot, "a", "b")},
+		{e: "s/a//", want: Sub(Dot, "a", "")},
+		{e: "s/a/\n/g", left: "/g", want: Sub(Dot, "a", "")},
+		{e: "s/(.*)/a\\1", want: Sub(Dot, "(.*)", "a\\1")},
+		{e: ".s/a/b", want: Sub(Dot, "a", "b")},
+		{e: "#1+1s/a/b", want: Sub(Rune(1).Plus(Line(1)), "a", "b")},
+		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "a", "b")},
+		{e: " #1 + 1 s/a/b", want: Sub(Rune(1).Plus(Line(1)), "a", "b")},
+		{e: "s/a/b/xyz", left: "xyz", want: Sub(Dot, "a", "b")},
+		{e: "s/a/b\nxyz", left: "xyz", want: Sub(Dot, "a", "b")},
+		{e: "s1/a/b", want: Sub(Dot, "a", "b")},
+		{e: "s/a/b/g", want: SubGlobal(Dot, "a", "b")},
+		{e: " #1 + 1 s/a/b/g", want: SubGlobal(Rune(1).Plus(Line(1)), "a", "b")},
+		{e: "s2/a/b", want: Substitute{A: Dot, RE: "a", With: "b", From: 2}},
+		{e: "s2;a;b", want: Substitute{A: Dot, RE: "a", With: "b", From: 2}},
+		{e: "s1000/a/b", want: Substitute{A: Dot, RE: "a", With: "b", From: 1000}},
+		{e: "s 2 /a/b", want: Substitute{A: Dot, RE: "a", With: "b", From: 2}},
+		{e: "s 1000 /a/b/g", want: Substitute{A: Dot, RE: "a", With: "b", Global: true, From: 1000}},
+		{e: "s", want: Sub(Dot, "", "")},
+		{e: "s\nabc", want: Sub(Dot, "", ""), left: "abc"},
+		{e: "s/", want: Sub(Dot, "", "")},
+		{e: "s//b", want: Sub(Dot, "", "b")},
+		{e: "s/\n/b", want: Sub(Dot, "", ""), left: "/b"},
 		{e: "s" + strconv.FormatInt(math.MaxInt64, 10) + "0" + "/a/b/g", err: "value out of range"},
 		{e: "s/*", err: "missing operand"},
 
@@ -1101,7 +1103,7 @@ func TestEd(t *testing.T) {
 		e, err := Ed(rs)
 
 		if test.err != "" {
-			if !regexp.MustCompile(test.err).MatchString(err.Error()) {
+			if err == nil || !regexp.MustCompile(test.err).MatchString(err.Error()) {
 				t.Errorf(`Ed(%q)=%q,%v, want %q,%q`, test.e, e, err, test.want, test.err)
 			}
 			continue

--- a/edit/editor_test.go
+++ b/edit/editor_test.go
@@ -70,8 +70,8 @@ func TestWhere(t *testing.T) {
 		{init: "Hello\n 世界!", a: End, at: addr{10, 10}},
 		{init: "Hello\n 世界!", a: Line(1), at: addr{0, 6}},
 		{init: "Hello\n 世界!", a: Line(2), at: addr{6, 10}},
-		{init: "Hello\n 世界!", a: Regexp("/Hello"), at: addr{0, 5}},
-		{init: "Hello\n 世界!", a: Regexp("/世界"), at: addr{7, 9}},
+		{init: "Hello\n 世界!", a: Regexp("Hello"), at: addr{0, 5}},
+		{init: "Hello\n 世界!", a: Regexp("世界"), at: addr{7, 9}},
 	}
 	for _, test := range tests {
 		ed := NewEditor(NewBuffer())
@@ -97,7 +97,7 @@ func TestWriterTo(t *testing.T) {
 		{init: "", a: End, want: "", dot: addr{}},
 		{init: "", a: Rune(0), want: "", dot: addr{}},
 		{init: "Hello, 世界", a: All, want: "Hello, 世界", dot: addr{0, 9}},
-		{init: "Hello, 世界", a: Regexp("/Hello/"), want: "Hello", dot: addr{0, 5}},
+		{init: "Hello, 世界", a: Regexp("Hello"), want: "Hello", dot: addr{0, 5}},
 		{init: "Hello, 世界", a: End, want: "", dot: addr{9, 9}},
 		{init: "Hello, 世界", a: Rune(0), want: "", dot: addr{}},
 		{init: "a\nb\nc\n", a: Line(0), want: "", dot: addr{}},
@@ -141,7 +141,7 @@ func TestReaderFrom(t *testing.T) {
 		{init: "Hello, 世界", a: End, read: "", want: "Hello, 世界", dot: addr{9, 9}},
 		{init: "Hello, 世界", a: All, read: "", want: "", dot: addr{0, 0}},
 		{init: "Hello, 世界", a: All, read: "αβξ", want: "αβξ", dot: addr{0, 3}},
-		{init: "Hello, 世界", a: Regexp("/世界/"), read: "World", want: "Hello, World", dot: addr{7, 12}},
+		{init: "Hello, 世界", a: Regexp("世界"), read: "World", want: "Hello, World", dot: addr{7, 12}},
 		{init: "a\nb\nc\n", a: Line(0), read: "z\n", want: "z\na\nb\nc\n", dot: addr{0, 2}},
 		{init: "a\nb\nc\n", a: Line(1), read: "z\n", want: "z\nb\nc\n", dot: addr{0, 2}},
 		{init: "a\nb\nc\n", a: Line(2), read: "z\n", want: "a\nz\nc\n", dot: addr{2, 4}},

--- a/re1/delim.go
+++ b/re1/delim.go
@@ -1,0 +1,75 @@
+package re1
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// RemoveDelimiter interprets the first rune of the regexp as a delimiter,
+// and returns the delimiter and the regexp with the delimiter removed.
+//
+// The given regexp is not checked for validity.
+// If the regexp is valid, the return is guaranteed to be valid.
+// If the regexp is invalid, there is no guarantee on the validity of the return.
+func RemoveDelimiter(regexp string) (rune, string) {
+	if len(regexp) == 0 {
+		return 0, ""
+	}
+	var s []rune
+	var d rune
+	var esc, class bool
+	d, w := utf8.DecodeRuneInString(regexp)
+	for _, r := range regexp[w:] {
+		if !esc && !class && r == d {
+			break
+		}
+		if esc && r == d {
+			// Escaped delimiter, strip the escape.
+			s = s[:len(s)-1]
+		}
+		s = append(s, r)
+		if r == '[' {
+			class = true
+		} else if class && r == ']' {
+			class = false
+		}
+		esc = !esc && r == '\\'
+	}
+	return d, string(s)
+}
+
+// AddDelimiter returns the regexp, delimited by d.
+// The given regexp is assumed to be non-delimited.
+//
+// The given regexp is not checked for validity.
+// If the regexp is valid, the return is guaranteed to be valid.
+// If the regexp is invalid, there is no guarantee on the validity of the return.
+func AddDelimiter(d rune, regexp string) string {
+	s := []rune{d}
+	var esc, class bool
+	for _, r := range regexp {
+		if r == d && !class {
+			if esc && strings.ContainsRune(Meta, d) {
+				// Change escaped meta characters matching the delimiter
+				// to character classes.
+				s = append(s[:len(s)-1], '[', d, ']')
+				esc = false
+				continue
+			}
+			if !esc {
+				s = append(s, '\\')
+			}
+		}
+		s = append(s, r)
+		if r == '[' {
+			class = true
+		} else if class && r == ']' {
+			class = false
+		}
+		esc = !esc && r == '\\'
+	}
+	if esc {
+		s = append(s, '\\')
+	}
+	return string(append(s, d))
+}

--- a/re1/delim_test.go
+++ b/re1/delim_test.go
@@ -1,0 +1,193 @@
+package re1
+
+import "testing"
+
+func TestRemoveDelimiter(t *testing.T) {
+	tests := []struct {
+		name    string
+		in, out string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			out:  "",
+		},
+		{
+			name: "no ending delimiter",
+			in:   "/abc",
+			out:  "abc",
+		},
+		{
+			name: "ending delimiter",
+			in:   "/abc/",
+			out:  "abc",
+		},
+		{
+			name: "escaped delimiter",
+			in:   `/ab\/c`,
+			out:  `ab/c`,
+		},
+		{
+			name: "escaped delimiter at start",
+			in:   `/\/abc`,
+			out:  `/abc`,
+		},
+		{
+			name: "escaped delimiter at end",
+			in:   `/abc\/`,
+			out:  `abc/`,
+		},
+		{
+			name: "charclass delimiter",
+			in:   `/ab[/]c`,
+			out:  `ab[/]c`,
+		},
+		{
+			name: "escaped and charclass delimiter",
+			in:   `/a\/b[/]c/`,
+			out:  `a/b[/]c`,
+		},
+		{
+			name: "non-ASCII delimiter",
+			in:   `☺abc☺`,
+			out:  `abc`,
+		},
+		{
+			name: "escaped and charclass non-ASCII delimiter",
+			in:   `☺a\☺b[☺]c☺`,
+			out:  `a☺b[☺]c`,
+		},
+		{
+			name: "[ in charclass",
+			in:   `/abc[[/]`,
+			out:  `abc[[/]`,
+		},
+		{
+			name: "escaped ] in charclass",
+			in:   `/abc[/\]]`,
+			out:  `abc[/\]]`,
+		},
+		{
+			name: "trailing escape",
+			in:   `/abc\`,
+			out:  `abc\`,
+		},
+	}
+	for _, test := range tests {
+		if _, str := RemoveDelimiter(test.in); str != test.out {
+			t.Errorf("%s (%q).String()=%q, want %q",
+				test.name, test.in, str, test.out)
+		}
+	}
+}
+
+func TestAddDelimiter(t *testing.T) {
+	tests := []struct {
+		name    string
+		in, out string
+		delim   rune
+	}{
+		{
+			name:  "empty",
+			in:    "",
+			delim: '/',
+			out:   "//",
+		},
+		{
+			name:  "simple",
+			in:    `abc`,
+			delim: '/',
+			out:   `/abc/`,
+		},
+		{
+			name:  "escape delimiter",
+			in:    `ab/c`,
+			delim: '/',
+			out:   `/ab\/c/`,
+		},
+		{
+			name:  "already escaped delimiter",
+			in:    `ab\/c`,
+			delim: '/',
+			out:   `/ab\/c/`,
+		},
+		{
+			name:  "charclass delimiter",
+			in:    `ab[/]c`,
+			delim: '/',
+			out:   `/ab[/]c/`,
+		},
+		{
+			name:  "escape meta delimiter",
+			in:    `abc*`,
+			delim: '*',
+			out:   `*abc\**`,
+		},
+		{
+			name:  "already escaped meta delimiter",
+			in:    `a\*`,
+			delim: '*',
+			out:   `*a[*]*`,
+		},
+		{
+			name:  "charclass meta delimiter",
+			in:    `abc\*`,
+			delim: '*',
+			out:   `*abc[*]*`,
+		},
+		{
+			name:  "obrace delimiter",
+			in:    `a[xyz]b`,
+			delim: '[',
+			out:   `[a\[xyz]b[`,
+		},
+		{
+			name:  "obrace delimiter add charclass",
+			in:    `a\[b`,
+			delim: '[',
+			out:   `[a[[]b[`,
+		},
+		{
+			name:  "trailing escape",
+			in:    `abc\`,
+			delim: '/',
+			out:   `/abc\\/`,
+		},
+		{
+			name:  "only escape",
+			in:    `\`,
+			delim: '/',
+			out:   `/\\/`,
+		},
+		{
+			name:  "escape in charclass",
+			in:    `[\]]`,
+			delim: '/',
+			out:   `/[\]]/`,
+		},
+		{
+			name:  "escaped delim in charclass",
+			in:    `[\/]`,
+			delim: '/',
+			out:   `/[\/]/`,
+		},
+		{
+			name:  "double escape",
+			in:    `\\[\\]`,
+			delim: '/',
+			out:   `/\\[\\]/`,
+		},
+		{
+			name:  "double escape before delimiter",
+			in:    `\\/`,
+			delim: '/',
+			out:   `/\\\//`,
+		},
+	}
+	for _, test := range tests {
+		if str := AddDelimiter(test.delim, test.in); str != test.out {
+			t.Errorf("%s (%q).DelimitedString(%q)=%q, want %q",
+				test.name, test.in, test.delim, str, test.out)
+		}
+	}
+}


### PR DESCRIPTION
Don't require delimiters for regexps.
Properly escape delimiters in Substitution edits.