### PR TITLE
Disallow right-associative and invalid precedence addresses.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -200,15 +200,15 @@ func (e change) String() string {
 }
 
 func (e change) do(ed *Editor, _ io.Writer) (addr, error) {
-	switch e.op {
-	case 'a':
-		e.a = e.a.Plus(Rune(0))
-	case 'i':
-		e.a = e.a.Minus(Rune(0))
-	}
 	at, err := e.a.where(ed)
 	if err != nil {
 		return addr{}, err
+	}
+	switch e.op {
+	case 'a':
+		at.from = at.to
+	case 'i':
+		at.to = at.from
 	}
 	unesc := unescape(e.str, nil)
 	return at, pend(ed, at, runes.StringReader(unesc))


### PR DESCRIPTION
Also fix a bug where , and ; were parsed as right-associative instead of left.

The string representation can only have one associativity. If we allow both left and right associative addresses, then one of them must not have a string representation.
For example,
The string representation of `Line(0).To(Line(1).To(Line(2)))` would be `0,1,2`.
The string representation of `Line(0).To(Line(1)).To(Line(2))` would be `0,1,2`.
But `0,1,2` parses right-associative so the first is wrong. It has no valid string representation.
Now, `Line(0).To(Line(1).To(Line(2)))` is not possible,
because `Line(1).To(Line(2))` returns an Address,
but `Line(0).To(·)` requires an AdditiveAddress.

In addition, we used to allow , and ; to take precedence over + and -.
One could write `Line(0).To(Line(1)).Plus(Line(2))`. This is invalid in sam and acme.
It also has the same string representation ambiguity problem:
The string representation of `Line(0).To(Line(1)).Plus(Line(2))` would be `0,1+2`.
The string representation of `Line(0).To(Line(1).Plus(Line(2)))` would be `0,1+2`.
But `0,1+2` parses with + binding tighter than , so the first is wrong. It has no valid string representation.
Now, `Line(0).To(Line(1)).Plus(Line(2))` is not possible,
because `Line(0).To(Line(1))` returns an Address,
and Address has no Plus method.

Fixes #182.