### PR TITLE
Evaluate Regexp addresses relative to Dot, not 0.

### DIFF
--- a/edit/addr.go
+++ b/edit/addr.go
@@ -35,8 +35,8 @@ type Address interface {
 	// but with dot set to the receiver address
 	// and with the argument evaluated from the end of the reciver
 	Then(AdditiveAddress) Address
+	// Where returns the addr of the Address.
 	where(*Editor) (addr, error)
-	whereFrom(from int64, ed *Editor) (addr, error)
 }
 
 // A addr identifies a substring within a buffer
@@ -93,17 +93,13 @@ func (a compoundAddr) String() string {
 }
 
 func (a compoundAddr) where(ed *Editor) (addr, error) {
-	return a.whereFrom(0, ed)
-}
-
-func (a compoundAddr) whereFrom(from int64, ed *Editor) (addr, error) {
-	a1, err := a.a1.whereFrom(from, ed)
+	a1, err := a.a1.where(ed)
 	if err != nil {
 		return addr{}, err
 	}
 	switch a.op {
 	case ',':
-		a2, err := a.a2.whereFrom(from, ed)
+		a2, err := a.a2.where(ed)
 		if err != nil {
 			return addr{}, err
 		}
@@ -111,7 +107,7 @@ func (a compoundAddr) whereFrom(from int64, ed *Editor) (addr, error) {
 	case ';':
 		origDot := ed.marks['.']
 		ed.marks['.'] = a1
-		a2, err := a.a2.whereFrom(a1.to, ed)
+		a2, err := a.a2.where(ed)
 		if err != nil {
 			ed.marks['.'] = origDot // Restore dot on error.
 			return addr{}, err
@@ -136,11 +132,14 @@ type AdditiveAddress interface {
 	// of the argument address evaluated in reverse
 	// from the start of the receiver.
 	Minus(SimpleAddress) AdditiveAddress
+	// WhereFrom returns the addr of the AdditiveAddress,
+	// relative to the from point.
+	whereFrom(from int64, ed *Editor) (addr, error)
 }
 
 type addAddr struct {
 	op rune
-	a1 Address
+	a1 AdditiveAddress
 	a2 SimpleAddress
 }
 
@@ -164,9 +163,7 @@ func (a addAddr) String() string {
 	return a.a1.String() + string(a.op) + a.a2.String()
 }
 
-func (a addAddr) where(ed *Editor) (addr, error) {
-	return a.whereFrom(0, ed)
-}
+func (a addAddr) where(ed *Editor) (addr, error) { return a.whereFrom(0, ed) }
 
 func (a addAddr) whereFrom(from int64, ed *Editor) (addr, error) {
 	a1, err := a.a1.whereFrom(from, ed)
@@ -193,6 +190,7 @@ type SimpleAddress interface {
 }
 
 type simpAddrImpl interface {
+	where(*Editor) (addr, error)
 	whereFrom(from int64, ed *Editor) (addr, error)
 	String() string
 	reverse() SimpleAddress
@@ -218,13 +216,13 @@ func (a simpleAddr) Minus(a2 SimpleAddress) AdditiveAddress {
 	return addAddr{op: '-', a1: a, a2: a2}
 }
 
-func (a simpleAddr) where(ed *Editor) (addr, error) {
-	return a.whereFrom(0, ed)
-}
-
 type dotAddr struct{}
 
 func (dotAddr) String() string { return "." }
+
+func (a dotAddr) where(ed *Editor) (addr, error) {
+	return a.whereFrom(0, ed)
+}
 
 func (dotAddr) whereFrom(_ int64, ed *Editor) (addr, error) {
 	a := ed.marks['.']
@@ -240,6 +238,8 @@ type endAddr struct{}
 
 func (endAddr) String() string { return "$" }
 
+func (a endAddr) where(ed *Editor) (addr, error) { return a.whereFrom(0, ed) }
+
 func (endAddr) whereFrom(_ int64, ed *Editor) (addr, error) {
 	return addr{from: ed.buf.size(), to: ed.buf.size()}, nil
 }
@@ -254,6 +254,8 @@ type markAddr rune
 func Mark(r rune) SimpleAddress { return simpleAddr{markAddr(r)} }
 
 func (m markAddr) String() string { return "'" + string(rune(m)) }
+
+func (m markAddr) where(ed *Editor) (addr, error) { return m.whereFrom(0, ed) }
 
 func (m markAddr) whereFrom(_ int64, ed *Editor) (addr, error) {
 	a := ed.marks[rune(m)]
@@ -277,6 +279,8 @@ func (n runeAddr) String() string {
 	}
 	return "#" + strconv.FormatInt(int64(n), 10)
 }
+
+func (n runeAddr) where(ed *Editor) (addr, error) { return n.whereFrom(0, ed) }
 
 func (n runeAddr) whereFrom(from int64, ed *Editor) (addr, error) {
 	m := from + int64(n)
@@ -309,6 +313,8 @@ func (l lineAddr) String() string {
 	}
 	return n
 }
+
+func (l lineAddr) where(ed *Editor) (addr, error) { return l.whereFrom(0, ed) }
 
 func (l lineAddr) whereFrom(from int64, ed *Editor) (addr, error) {
 	if l.neg {
@@ -408,6 +414,9 @@ type reAddr struct {
 }
 
 // Regexp returns an address identifying the next match of a regular expression.
+// If Regexp as the right-hand operand of a + or -,
+// then next relative to the left-hand operand.
+// Otherwise, next is relative to dot.
 //
 // The regular expression must use the syntax of the re1 package:
 // http://godoc.org/github.com/eaburns/T/re1.
@@ -459,6 +468,14 @@ type reverse struct{ *forward }
 
 func (rs *reverse) Rune(i int64) rune {
 	return rs.forward.Rune(rs.Size() - i - 1)
+}
+
+func (r reAddr) where(ed *Editor) (addr, error) {
+	dot := ed.marks['.']
+	if r.opts.Reverse {
+		return r.whereFrom(dot.from, ed)
+	}
+	return r.whereFrom(dot.to, ed)
 }
 
 func (r reAddr) whereFrom(from int64, ed *Editor) (a addr, err error) {

--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -611,19 +611,24 @@ var regexpTests = []editTest{
 		do:    address(Regexp("世界")),
 		want:  "{..}Hello {a}世界{a}",
 	},
-	// BUG(eaburns): All tests below are subject to issue #180. Regexps should implicitly be relative to dot unless they are the operand of + or -.
-	//	{
-	//		name:  "relative to dot",
-	//		given: "abc{..}xyzabc",
-	//		do:    address(Regexp("abc")),
-	//		want:  "abc{..}xyz{a}abc{a}",
-	//	},
-	//	{
-	//		name:  "relative to dot in a range",
-	//		given: "abc{..}xyzabc",
-	//		do:    address(Rune(2).To(Regexp("abc"))),
-	//		want:  "ab{a}c{..}xyzabc{a}",
-	//	},
+	{
+		name:  "forward relative to dot.to",
+		given: "abcx{.}xxabcxx{.}xabc",
+		do:    address(Regexp("abc")),
+		want:  "abcx{.}xxabcxx{.}x{a}abc{a}",
+	},
+	{
+		name:  "reverse relative to dot.from",
+		given: "abcx{.}xxabcxx{.}xabc",
+		do:    address(Regexp("?abc")),
+		want:  "{a}abc{a}x{.}xxabcxx{.}xabc",
+	},
+	{
+		name:  "relative to dot in a range",
+		given: "abc{..}xyzabc",
+		do:    address(Rune(2).To(Regexp("abc"))),
+		want:  "ab{a}c{..}xyzabc{a}",
+	},
 	{
 		name:  "relative to a1 in a plus",
 		given: "12abc{..}xyzabc",
@@ -954,43 +959,41 @@ var thenTests = []editTest{
 		do:    address(Rune(0).Then(End)),
 		want:  "{..aa}",
 	},
-
-	// BUG(eaburns): #179, don't treat ; like a range-based +.
 	{
 		name:  "simple address then simple address",
 		given: "{..}abc",
 		do:    address(Rune(1).Then(Rune(2))),
-		want:  "a{..a}bc{a}",
+		want:  "a{..a}b{a}c",
 	},
 	{
 		name:  "simple address then compound address",
 		given: "{..}abc",
 		do:    address(Rune(1).Then(Rune(1).Plus(Rune(1)))),
-		want:  "a{..a}bc{a}",
+		want:  "a{..a}b{a}c",
 	},
 	{
 		name:  "compound address then simple address",
 		given: "{..}abcde",
 		do:    address(Rune(0).Plus(Rune(1)).Then(Rune(3))),
-		want:  "a{..a}bcd{a}e",
+		want:  "a{..a}bc{a}de",
 	},
 	{
 		name:  "compound address then compound address",
 		given: "{..}abcde",
 		do:    address(Rune(0).Plus(Rune(1)).Then(Rune(2).Plus(Rune(1)))),
-		want:  "a{..a}bcd{a}e",
+		want:  "a{..a}bc{a}de",
 	},
 	{
 		name:  "range address then simple address",
 		given: "{..}abcdef",
 		do:    address(Rune(0).To(Rune(1)).Then(Rune(2))),
-		want:  "{.a}a{.}bc{a}def",
+		want:  "{.a}a{.}b{a}cdef",
 	},
 	{
 		name:  "range address then compound address",
 		given: "{..}abcde",
 		do:    address(Rune(0).To(Rune(1)).Then(Rune(2).Plus(Rune(1)))),
-		want:  "{.a}a{.}bcd{a}e",
+		want:  "{.a}a{.}bc{a}de",
 	},
 	{
 		name:  "a2 evaluated from end of a1",


### PR DESCRIPTION
Evaluate regexp addresses relative to . and don't compute ; as +.
Regexp addresses were only being evaluated relative to 0 or $. But they should be relative to . instead. Also ; would set dot to a1 and evaluate +a2 for the end of the range. Instead, set dot to a1 and evaluate a2 relative to its default (which is most-often `0`, but is `ed.marks['.'].to` for regexps).

Fixes #180.
Fixes #179.