### PR TITLE
Close buffer in address benchmarks.

### DIFF
--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -55,6 +55,7 @@ func BenchmarkLinex1K(b *testing.B) { benchmarkLine(b, 1<<10) }
 
 func benchmarkRegexp(b *testing.B, re string, n int) {
 	ed, _ := makeEditor(n)
+	defer ed.buf.Close()
 	b.ResetTimer()
 	b.SetBytes(int64(n))
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Fixes another tmp file leak.