### PR TITLE
travis.yml: use a patched goveralls to fix coverage under-reporting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
 
 install:
     - go get golang.org/x/tools/cmd/cover
-    - go get github.com/mattn/goveralls
+    - go get github.com/eaburns/goveralls
+    - (cd $HOME/gopath/src/github.com/eaburns/goveralls && git checkout issue61 && go install)
     - go get golang.org/x/tools/cmd/vet
     - go get github.com/golang/lint/golint
     - go get -d -v ./... && go build -v ./...


### PR DESCRIPTION
Currently, goveralls under reports coverage for if-statements with initialization statements. Instead of using the master repo, point at a patched version of goveralls that contains the fix.

This can be reverted once the fix is in upstream.