### PR TITLE
edit: defer reporting Editor.Change errors until Editor.Apply.

### DIFF
--- a/edit/addr_bench_test.go
+++ b/edit/addr_bench_test.go
@@ -29,9 +29,7 @@ func makeEditor(n int) (buf *Buffer, lines int, runes int64) {
 		}
 	}
 	buf = NewBuffer()
-	if err := buf.Change(Span{}, bytes.NewReader(data)); err != nil {
-		panic(err)
-	}
+	buf.Change(Span{}, bytes.NewReader(data))
 	if err := buf.Apply(); err != nil {
 		panic(err)
 	}

--- a/edit/addr_test.go
+++ b/edit/addr_test.go
@@ -281,9 +281,7 @@ func TestIOErrors(t *testing.T) {
 		buf := newBuffer(r)
 		defer buf.Close()
 
-		if err := buf.Change(Span{}, strings.NewReader(helloWorld)); err != nil {
-			t.Fatalf("buf.Change(Span{}, %q)=%q, want nil", helloWorld, err)
-		}
+		buf.Change(Span{}, strings.NewReader(helloWorld))
 		if err := buf.Apply(); err != nil {
 			t.Fatalf("buf.Apply()=%q, want nil", err)
 		}

--- a/edit/buffer.go
+++ b/edit/buffer.go
@@ -16,6 +16,7 @@ type Buffer struct {
 	pending, undo, redo *log
 	seq                 int32
 	marks               map[rune]Span
+	error               error
 }
 
 // NewBuffer returns a new, empty Buffer.
@@ -122,16 +123,22 @@ func (buf *Buffer) Reader(s Span) io.Reader {
 	return runes.UTF8Reader(rr)
 }
 
-func (buf *Buffer) Change(s Span, r io.Reader) error {
-	rr := runes.RunesReader(bufio.NewReader(r))
-	err := buf.pending.append(buf.seq, s, rr)
-	if err != nil {
-		buf.pending.clear()
+func (buf *Buffer) Change(s Span, r io.Reader) {
+	if buf.error != nil {
+		return
 	}
-	return err
+	rr := runes.RunesReader(bufio.NewReader(r))
+	buf.error = buf.pending.append(buf.seq, s, rr)
 }
 
 func (buf *Buffer) Apply() error {
+	if buf.error != nil {
+		err := ChangeError{buf.error}
+		buf.error = nil
+		buf.pending.clear()
+		return err
+	}
+
 	if !inSequence(buf.pending) {
 		return ErrOutOfSequence
 	}

--- a/edit/buffer_test.go
+++ b/edit/buffer_test.go
@@ -64,23 +64,48 @@ func TestBufferBadReader(t *testing.T) {
 	}
 }
 
+type errorReader struct{ err error }
+
+func (r errorReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestBufferChangeError(t *testing.T) {
+	testErr := errors.New("test error")
+
+	buf := NewBuffer()
+	defer buf.Close()
+
+	buf.Change(Span{}, strings.NewReader("Hello,"))
+	buf.Change(Span{}, errorReader{testErr})
+	buf.Change(Span{buf.Size(), buf.Size()}, strings.NewReader(" World!"))
+	if err := buf.Apply(); err.Error() != testErr.Error() {
+		t.Fatalf("buf.Apply()=%v, want %v", err, testErr)
+	}
+
+	// Make sure we can still use the buffer.
+	const str = "Goodbye"
+	buf.Change(Span{}, strings.NewReader(str))
+	if err := buf.Apply(); err != nil {
+		t.Fatalf("buf.Apply()=%v, want nil", err)
+	}
+
+	// Make sure that "Hello, World!" was never written to the bufer.
+	all, err := ioutil.ReadAll(buf.Reader(Span{0, buf.Size()}))
+	if string(all) != str || err != nil {
+		t.Fatalf("ioutil.ReadAll(buf)=%q,%v, want %q,nil", string(all), err, str)
+	}
+}
+
 func TestBufferChangeOutOfSequence(t *testing.T) {
 	buf := NewBuffer()
 	defer buf.Close()
 	const init = "Hello, 世界"
-	if err := buf.Change(Span{}, strings.NewReader(init)); err != nil {
-		panic(err)
-	}
+	buf.Change(Span{}, strings.NewReader(init))
 	if err := buf.Apply(); err != nil {
 		panic(err)
 	}
 
-	if err := buf.Change(Span{10, 20}, strings.NewReader("")); err != nil {
-		panic(err)
-	}
-	if err := buf.Change(Span{0, 10}, strings.NewReader("")); err != nil {
-		panic(err)
-	}
+	buf.Change(Span{10, 20}, strings.NewReader(""))
+	buf.Change(Span{0, 10}, strings.NewReader(""))
 	if err := buf.Apply(); err != ErrOutOfSequence {
 		t.Errorf("buf.Apply()=%v, want %v", err, ErrOutOfSequence)
 	}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -2286,10 +2286,7 @@ func (test editTest) runFromString(t *testing.T) {
 func newTestBuffer(str string) *Buffer {
 	contents, marks := parseState(str)
 	buf := NewBuffer()
-	if err := buf.Change(Span{}, strings.NewReader(contents)); err != nil {
-		buf.Close()
-		panic(err)
-	}
+	buf.Change(Span{}, strings.NewReader(contents))
 	if err := buf.Apply(); err != nil {
 		buf.Close()
 		panic(err)


### PR DESCRIPTION
This cuts down on the error boilerplate code in the Edit implementations.
I also added setDot, which sets the '.' mark and panics on error.
It is called by Edit implementations after Address.Where computes a Span.
Such Spans can't be out of range or else Address.Where would have returned the error.