### PR TITLE
editor: rewrite the editor API to use paths instead of IDs.

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -1,7 +1,7 @@
 // Copyright © 2016, The T Authors.
 
 // Package editor provides a server that serves an HTTP editor API,
-// and a client for convenient access to the server.
+// and functions convenient client access to the server.
 package editor
 
 import (
@@ -11,46 +11,48 @@ import (
 	"github.com/eaburns/T/edit"
 )
 
-// A BufferInfo contains meta-information about a buffer.
-type BufferInfo struct {
-	// ID is the buffer's unique ID.
-	ID int `json:"id"`
+// A Buffer describes a buffer.
+type Buffer struct {
+	// ID is the ID of the buffer.
+	ID string `json:"id"`
+
+	// Path is the path to the buffer's resource.
+	Path string `json:"path"`
 
 	// Sequence is the sequence number of the last edit on the buffer.
 	Sequence int `json:"sequence"`
 }
 
-// An EditorInfo contains meta-information about an editor of a buffer.
-type EditorInfo struct {
-	// ID is the editor's unique ID.
-	ID int `json:"id"`
+// An Editor describes an editor.
+type Editor struct {
+	// ID is the ID of the editor.
+	ID string `json:"id"`
 
-	// BufferID is the ID of the edited buffer.
-	BufferID int `json:"bufferId"`
+	// Path is the path to the editor's resource.
+	Path string `json:"path"`
+
+	// BufferPath is the path to the editor's buffer's resource.
+	BufferPath string `json:"bufferPath"`
 }
 
-// An EditRequest requests that an editor perform an edit on its buffer.
-type EditRequest struct {
-	edit.Edit `json:"edit"`
-}
+type editRequest struct{ edit.Edit }
 
-func (req *EditRequest) MarshalText() ([]byte, error) { return []byte(req.String()), nil }
+func (e *editRequest) MarshalText() ([]byte, error) { return []byte(e.String()), nil }
 
-func (req *EditRequest) UnmarshalText(text []byte) error {
+func (e *editRequest) UnmarshalText(text []byte) error {
+	var err error
 	r := bytes.NewReader(text)
-	e, err := edit.Ed(r)
-	if err != nil {
+	if e.Edit, err = edit.Ed(r); err != nil {
 		return err
 	}
 	if l := r.Len(); l != 0 {
 		return errors.New("unexpected trailing text: " + string(text[l:]))
 	}
-	req.Edit = e
 	return nil
 }
 
-// An EditResponse contians the result of an edit performed by an editor.
-type EditResponse struct {
+// An EditResult is result of performing an edito on a buffer.
+type EditResult struct {
 	// Sequence is the sequence number unique to the edit.
 	Sequence int `json:"sequence"`
 


### PR DESCRIPTION
There's no more Client type. Instead, users maintain all necessary state in a url.URL (the url, path to methods, and in the future the token). The paths now use a much flatter namespace too:
/buffers is the list of buffers
/buffer/{id} is the buffer with the given ID.
/buffer/{id}/editors is the list of a buffer's editors
/editor/{id} is the editor with the given ID.