### PR TITLE
editor: remove /buffer/<id>/editors, list editors in the Buffer message.

### DIFF
--- a/editor/client.go
+++ b/editor/client.go
@@ -70,16 +70,6 @@ func BufferInfo(url *url.URL) (Buffer, error) {
 	return buf, nil
 }
 
-// EditorList does a GET and returns a list of Editors from the response body.
-// The URL is expected to point at the "editor" file of a buffer path.
-func EditorList(url *url.URL) ([]Editor, error) {
-	var list []Editor
-	if err := request(url, http.MethodGet, nil, &list); err != nil {
-		return nil, err
-	}
-	return list, nil
-}
-
 // NewEditor does a PUT and returns an Editor from the response body.
 // The URL is expected to point at the "editor" file of a buffer path.
 func NewEditor(url *url.URL) (Editor, error) {

--- a/editor/client.go
+++ b/editor/client.go
@@ -71,7 +71,7 @@ func BufferInfo(url *url.URL) (Buffer, error) {
 }
 
 // NewEditor does a PUT and returns an Editor from the response body.
-// The URL is expected to point at the "editor" file of a buffer path.
+// The URL is expected to point at a buffer path.
 func NewEditor(url *url.URL) (Editor, error) {
 	var ed Editor
 	if err := request(url, http.MethodPut, nil, &ed); err != nil {

--- a/editor/client.go
+++ b/editor/client.go
@@ -14,8 +14,13 @@ import (
 	"github.com/eaburns/T/edit"
 )
 
-// ErrNotFound indicates that a resource is not found.
-var ErrNotFound = errors.New("not found")
+var (
+	// ErrNotFound indicates that a resource is not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrRange indicates an out-of-range Address.
+	ErrRange = errors.New("bad range")
+)
 
 func request(url *url.URL, method string, body io.Reader, resp interface{}) error {
 	httpReq, err := http.NewRequest(method, url.String(), body)
@@ -38,13 +43,13 @@ func request(url *url.URL, method string, body io.Reader, resp interface{}) erro
 
 // Close does a DELETE.
 // The URL is expected to point at either a buffer path or an editor path.
-func Close(url *url.URL) error { return request(url, http.MethodDelete, nil, nil) }
+func Close(URL *url.URL) error { return request(URL, http.MethodDelete, nil, nil) }
 
 // BufferList does a GET and returns a list of Buffers from the response body.
 // The URL is expected to point at an editor server's buffers list.
-func BufferList(url *url.URL) ([]Buffer, error) {
+func BufferList(URL *url.URL) ([]Buffer, error) {
 	var list []Buffer
-	if err := request(url, http.MethodGet, nil, &list); err != nil {
+	if err := request(URL, http.MethodGet, nil, &list); err != nil {
 		return nil, err
 	}
 	return list, nil
@@ -52,9 +57,9 @@ func BufferList(url *url.URL) ([]Buffer, error) {
 
 // NewBuffer does a PUT and returns a Buffer from the response body.
 // The URL is expected to point at an editor server's buffers list.
-func NewBuffer(url *url.URL) (Buffer, error) {
+func NewBuffer(URL *url.URL) (Buffer, error) {
 	var buf Buffer
-	if err := request(url, http.MethodPut, nil, &buf); err != nil {
+	if err := request(URL, http.MethodPut, nil, &buf); err != nil {
 		return Buffer{}, err
 	}
 	return buf, nil
@@ -62,9 +67,9 @@ func NewBuffer(url *url.URL) (Buffer, error) {
 
 // BufferInfo does a GET and returns a Buffer from the response body.
 // The URL is expected to point at a buffer path.
-func BufferInfo(url *url.URL) (Buffer, error) {
+func BufferInfo(URL *url.URL) (Buffer, error) {
 	var buf Buffer
-	if err := request(url, http.MethodGet, nil, &buf); err != nil {
+	if err := request(URL, http.MethodGet, nil, &buf); err != nil {
 		return Buffer{}, err
 	}
 	return buf, nil
@@ -72,9 +77,9 @@ func BufferInfo(url *url.URL) (Buffer, error) {
 
 // NewEditor does a PUT and returns an Editor from the response body.
 // The URL is expected to point at a buffer path.
-func NewEditor(url *url.URL) (Editor, error) {
+func NewEditor(URL *url.URL) (Editor, error) {
 	var ed Editor
-	if err := request(url, http.MethodPut, nil, &ed); err != nil {
+	if err := request(URL, http.MethodPut, nil, &ed); err != nil {
 		return Editor{}, err
 	}
 	return ed, nil
@@ -82,18 +87,41 @@ func NewEditor(url *url.URL) (Editor, error) {
 
 // EditorInfo does a GET and returns an Editor from the response body.
 // The URL is expected to point at an editor path.
-func EditorInfo(url *url.URL) (Editor, error) {
+func EditorInfo(URL *url.URL) (Editor, error) {
 	var ed Editor
-	if err := request(url, http.MethodGet, nil, &ed); err != nil {
+	if err := request(URL, http.MethodGet, nil, &ed); err != nil {
 		return Editor{}, err
 	}
 	return ed, nil
 }
 
+// Reader returns an io.ReadCloser that reads the text from a given Address.
+// If non-nil, the returned io.ReadCloser must be closed by the caller.
+// If the Address is non-nil, it is set as the value of the addr URL parameter.
+// The URL is expected to point at an editor's text path.
+func Reader(URL *url.URL, addr edit.Address) (io.ReadCloser, error) {
+	urlCopy := *URL
+	if addr != nil {
+		vals := make(url.Values)
+		vals["addr"] = []string{addr.String()}
+		urlCopy.RawQuery += "&" + vals.Encode()
+	}
+
+	httpResp, err := http.Get(urlCopy.String())
+	if err != nil {
+		return nil, err
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		defer httpResp.Body.Close()
+		return nil, responseError(httpResp)
+	}
+	return httpResp.Body, nil
+}
+
 // Do POSTs a sequence of edits and returns a list of the EditResults
 // from the response body.
 // The URL is expected to point at an editor path.
-func Do(url *url.URL, edits ...edit.Edit) ([]EditResult, error) {
+func Do(URL *url.URL, edits ...edit.Edit) ([]EditResult, error) {
 	var eds []editRequest
 	for _, ed := range edits {
 		eds = append(eds, editRequest{ed})
@@ -103,16 +131,20 @@ func Do(url *url.URL, edits ...edit.Edit) ([]EditResult, error) {
 		return nil, err
 	}
 	var results []EditResult
-	if err := request(url, http.MethodPost, body, &results); err != nil {
+	if err := request(URL, http.MethodPost, body, &results); err != nil {
 		return nil, err
 	}
 	return results, nil
 }
 
 func responseError(resp *http.Response) error {
-	if resp.StatusCode == http.StatusNotFound {
+	switch resp.StatusCode {
+	case http.StatusNotFound:
 		return ErrNotFound
+	case http.StatusRequestedRangeNotSatisfiable:
+		return ErrRange
+	default:
+		data, _ := ioutil.ReadAll(resp.Body)
+		return errors.New(resp.Status + ": " + string(data))
 	}
-	data, _ := ioutil.ReadAll(resp.Body)
-	return errors.New(resp.Status + ": " + string(data))
 }

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -21,6 +21,9 @@ type Buffer struct {
 
 	// Sequence is the sequence number of the last edit on the buffer.
 	Sequence int `json:"sequence"`
+
+	// Editors containts the buffer's editors.
+	Editors []Editor `json:"editors"`
 }
 
 // An Editor describes an editor.

--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -337,7 +337,7 @@ func TestDo(t *testing.T) {
 	}
 }
 
-func TestDo_Nohthing(t *testing.T) {
+func TestDo_Nothing(t *testing.T) {
 	s := newServer()
 	defer s.close()
 

--- a/editor/server.go
+++ b/editor/server.go
@@ -80,21 +80,18 @@ func (s *Server) Close() error {
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
 // 	• Not Found if the buffer is not found.
-// 	  The body is the path to the buffer.
 //
 // 	DELETE deletes the buffer and all of its editors.
 // 	Returns:
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
 // 	• Not Found if the buffer is not found.
-// 	  The body is the path to the buffer.
 //
 // 	PUT creates a new editor for the buffer and returns its Editor.
 // 	Returns:
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
 // 	• Not Found if the buffer is not found.
-// 	  The body is the path to the buffer.
 //
 //  /editor/<ID> is the editor with the given ID.
 //
@@ -102,15 +99,13 @@ func (s *Server) Close() error {
 // 	Returns:
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
-// 	• Not Found if either the buffer or editor is not found.
-// 	  The body is the path to the buffer or editor.
+// 	• Not Found if the editor is not found.
 //
 // 	DELETE deletes the editor.
 // 	Returns:
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
-// 	• Not Found if either the buffer or editor is not found.
-// 	  The body is the path to the buffer or editor.
+// 	• Not Found if the editor editor is not found.
 //
 //  /editor/<ID>/text is the text that the editor edits.
 //
@@ -120,8 +115,7 @@ func (s *Server) Close() error {
 // 	Returns:
 // 	• OK on success.
 // 	• Internal Server Error on internal error.
-// 	• Not Found if either the buffer or editor is not found.
-// 	  The body is the path to the buffer or editor.
+// 	• Not Found if the editor is not found.
 // 	• Bad Request if the Edit list is malformed.
 //
 // Unless otherwise stated, the body of all error responses is the error message.

--- a/editor/server.go
+++ b/editor/server.go
@@ -112,6 +112,8 @@ func (s *Server) Close() error {
 // 	• Not Found if either the buffer or editor is not found.
 // 	  The body is the path to the buffer or editor.
 //
+//  /editor/<ID>/text is the text that the editor edits.
+//
 // 	POST performs an atomic sequence of edits on the buffer.
 // 	The body must be an ordered list of Edits.
 // 	The response is an ordered list of EditResult.
@@ -131,7 +133,7 @@ func (s *Server) RegisterHandlers(r *mux.Router) {
 	r.HandleFunc("/buffer/{id}", s.newEditor).Methods(http.MethodPut)
 	r.HandleFunc("/editor/{id}", s.editorInfo).Methods(http.MethodGet)
 	r.HandleFunc("/editor/{id}", s.closeEditor).Methods(http.MethodDelete)
-	r.HandleFunc("/editor/{id}", s.edit).Methods(http.MethodPost)
+	r.HandleFunc("/editor/{id}/text", s.edit).Methods(http.MethodPost)
 }
 
 // respond JSON encodes resp to w, and sends an Internal Server Error on failure.


### PR DESCRIPTION
It was somehow asymetrical that buffers had a special editors endpoint, but editors hada no special endpoint like /edit or /text for POSTing edits. Instead, just use /buffer/<id>. PUTting creates a new editor. To get the editors list, GET from the buffer; the editors are now listed in the Buffer message.