### PR TITLE
ui/text: various improvements and fixes.

### DIFF
--- a/ui/text/main.go
+++ b/ui/text/main.go
@@ -74,7 +74,7 @@ func loadFace() font.Face {
 	return face
 }
 
-func inin() { runtime.LockOSThread() }
+func init() { runtime.LockOSThread() }
 
 func main() { driver.Main(Main) }
 
@@ -93,7 +93,8 @@ func Main(scr screen.Screen) {
 	defer win.Release()
 
 	sz := image.Pt(width, height)
-	opts.Bounds = image.Rect(sz.X/20, sz.Y/20, sz.X-sz.X/20, sz.Y-sz.Y/20)
+	at := image.Pt(sz.X/20, sz.Y/20)
+	opts.Size = image.Pt(sz.X-sz.X/10, sz.Y-sz.Y/10)
 	setter := text.NewSetter(opts)
 	defer setter.Release()
 
@@ -141,7 +142,8 @@ func Main(scr screen.Screen) {
 		case mouse.Event:
 			switch e.Direction {
 			case mouse.DirPress:
-				a0 = txt.Index(image.Pt(int(e.X), int(e.Y)))
+				click := image.Pt(int(e.X), int(e.Y))
+				a0 = txt.Index(click.Sub(at))
 				a1 = a0
 				drag = true
 				txt = resetText(setter, txt, a0, a1)
@@ -155,7 +157,8 @@ func Main(scr screen.Screen) {
 					continue
 				}
 				a1Prev := a1
-				a1 = txt.Index(image.Pt(int(e.X), int(e.Y)))
+				click := image.Pt(int(e.X), int(e.Y))
+				a1 = txt.Index(click.Sub(at))
 				if a1 != a1Prev {
 					txt = resetText(setter, txt, a0, a1)
 					win.Send(paint.Event{})
@@ -164,13 +167,14 @@ func Main(scr screen.Screen) {
 
 		case size.Event:
 			sz = e.Size()
-			opts.Bounds = image.Rect(sz.X/20, sz.Y/20, sz.X-sz.X/20, sz.Y-sz.Y/20)
+			at = image.Pt(sz.X/20, sz.Y/20)
+			opts.Size = image.Pt(sz.X-sz.X/10, sz.Y-sz.Y/10)
 			setter.Reset(opts)
 			txt = resetText(setter, txt, a0, a1)
 
 		case paint.Event:
 			win.Fill(image.Rect(0, 0, sz.X, sz.Y), image.White, draw.Over)
-			txt.Draw(scr, win)
+			txt.Draw(at, scr, win)
 			win.Publish()
 		}
 	}

--- a/ui/text/main.go
+++ b/ui/text/main.go
@@ -173,7 +173,12 @@ func Main(scr screen.Screen) {
 			txt = resetText(setter, txt, a0, a1)
 
 		case paint.Event:
-			win.Fill(image.Rect(0, 0, sz.X, sz.Y), image.White, draw.Src)
+			bg := image.White
+			r := image.Rect(at.X, at.Y, at.X+opts.Size.X, at.Y+opts.Size.Y)
+			win.Fill(image.Rect(0, 0, sz.X, r.Min.Y), bg, draw.Src)             // top
+			win.Fill(image.Rect(0, r.Max.Y, sz.X, sz.Y), bg, draw.Src)          // bottom
+			win.Fill(image.Rect(0, r.Min.Y, r.Min.X, r.Max.Y), bg, draw.Src)    // left
+			win.Fill(image.Rect(r.Min.X, r.Min.Y, sz.X, r.Max.Y), bg, draw.Src) // right
 			txt.Draw(at, scr, win)
 			win.Publish()
 		}

--- a/ui/text/main.go
+++ b/ui/text/main.go
@@ -16,8 +16,9 @@ import (
 	"runtime"
 	"unicode/utf8"
 
-	"github.com/davecheney/profile"
 	"github.com/eaburns/T/ui/text"
+	"github.com/golang/freetype/truetype"
+	"github.com/pkg/profile"
 	"golang.org/x/exp/shiny/driver"
 	"golang.org/x/exp/shiny/screen"
 	"golang.org/x/image/font"
@@ -52,6 +53,26 @@ var (
 )
 
 func loadFace() font.Face {
+	file := path.Join(os.Getenv("HOME"), ".fonts", "Roboto-Regular.ttf")
+	f, err := os.Open(file)
+	if err != nil {
+		return loadPlan9Face()
+	}
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return loadPlan9Face()
+	}
+	ttf, err := truetype.Parse(data)
+	if err != nil {
+		return loadPlan9Face()
+	}
+	return truetype.NewFace(ttf, &truetype.Options{
+		Size: 11, // pt
+		DPI:  96,
+	})
+}
+
+func loadPlan9Face() font.Face {
 	dir := path.Join(os.Getenv("PLAN9"), "font/lucsans")
 	file := path.Join(dir, "unicode.8.font")
 	f, err := os.Open(file)
@@ -80,7 +101,7 @@ func main() { driver.Main(Main) }
 
 // Main is the logical main function, the real main function is hijacked by shiny.
 func Main(scr screen.Screen) {
-	defer profile.Start(profile.CPUProfile).Stop()
+	defer profile.Start(profile.MemProfile).Stop()
 
 	width, height := 300, 300
 	win, err := scr.NewWindow(&screen.NewWindowOptions{

--- a/ui/text/main.go
+++ b/ui/text/main.go
@@ -173,7 +173,7 @@ func Main(scr screen.Screen) {
 			txt = resetText(setter, txt, a0, a1)
 
 		case paint.Event:
-			win.Fill(image.Rect(0, 0, sz.X, sz.Y), image.White, draw.Over)
+			win.Fill(image.Rect(0, 0, sz.X, sz.Y), image.White, draw.Src)
 			txt.Draw(at, scr, win)
 			win.Publish()
 		}

--- a/ui/text/text.go
+++ b/ui/text/text.go
@@ -341,7 +341,7 @@ func (l *line) len() int {
 // Draw draws the text to the Window.
 func (t *Text) Draw(at image.Point, scr screen.Screen, win screen.Window) {
 	b := image.Rectangle{Min: at, Max: at.Add(t.size)}
-	win.Fill(b, t.setter.opts.DefaultStyle.BG, draw.Over)
+	win.Fill(b, t.setter.opts.DefaultStyle.BG, draw.Src)
 
 	pad := t.setter.opts.Padding
 	textWidth := b.Dx() - 2*pad
@@ -377,7 +377,7 @@ func (t *Text) Draw(at image.Point, scr screen.Screen, win screen.Window) {
 			if len(l.spans) > 0 {
 				bg = l.spans[len(l.spans)-1].BG
 			}
-			win.Fill(image.Rect(x0+dx, y, b.Max.X-pad, y1), bg, draw.Over)
+			win.Fill(image.Rect(x0+dx, y, b.Max.X-pad, y1), bg, draw.Src)
 		}
 	}
 }
@@ -387,7 +387,7 @@ func drawLine(t *Text, l *line, img draw.Image) {
 		fg := image.NewUniform(sp.FG)
 		bg := image.NewUniform(sp.BG)
 		box := image.Rect(int(sp.x0>>6), 0, int(sp.x1>>6), int(l.h>>6))
-		draw.Draw(img, box, bg, image.ZP, draw.Over)
+		draw.Draw(img, box, bg, image.ZP, draw.Src)
 		x := sp.x0
 		for i, r := range sp.text {
 			if r == '\t' {

--- a/ui/text/text.go
+++ b/ui/text/text.go
@@ -237,8 +237,8 @@ func (s *Setter) Set() *Text {
 			l.buf = nil
 		}
 	}
-	s.reuseLines = nil
 	s.lines = s.reuseLines[:0]
+	s.reuseLines = nil
 	return t
 }
 

--- a/ui/text/text.go
+++ b/ui/text/text.go
@@ -123,13 +123,25 @@ func (s *Setter) AddStyle(sty *Style, text []byte) {
 	if len(text) == 0 {
 		return
 	}
+
+	ymax := fixed.I(s.opts.Size.Y)
+	var h fixed.Int26_6
+	for _, l := range s.lines {
+		h += l.h
+	}
+
 	m := s.opts.DefaultStyle.Face.Metrics()
 	if len(s.lines) == 0 {
 		s.lines = append(s.lines, &line{h: m.Height, a: m.Ascent})
 	}
 	for len(text) > 0 {
+		if h > ymax {
+			// Tall enough.
+			return
+		}
 		text = add1(s, sty, text)
 		if len(text) > 0 {
+			h += s.lines[len(s.lines)-1].h
 			s.lines = append(s.lines, &line{h: m.Height, a: m.Ascent})
 		}
 	}

--- a/ui/text/text.go
+++ b/ui/text/text.go
@@ -340,17 +340,18 @@ func (l *line) len() int {
 
 // Draw draws the text to the Window.
 func (t *Text) Draw(at image.Point, scr screen.Screen, win screen.Window) {
-	b := image.Rectangle{Min: at, Max: at.Add(t.size)}
-	win.Fill(b, t.setter.opts.DefaultStyle.BG, draw.Src)
-
 	pad := t.setter.opts.Padding
-	textWidth := b.Dx() - 2*pad
+	bg := t.setter.opts.DefaultStyle.BG
+	x0, y0, x1, y1 := at.X, at.Y, at.X+t.size.X, at.Y+t.size.Y
+
 	var y int
-	x0, y1 := b.Min.X+pad, b.Min.Y+pad
+	x, ynext := at.X+pad, at.Y+pad
+	textWidth := (x1 - x0) - 2*pad
 	for _, l := range t.lines {
-		y = y1
-		y1 = y + int(l.h>>6)
-		if y1 > b.Max.Y-pad {
+		y = ynext
+		ynext = y + int(l.h>>6)
+		if ynext > y1-pad {
+			ynext = y
 			break
 		}
 		if l.buf == nil && int(l.w>>6) > 0 {
@@ -362,24 +363,26 @@ func (t *Text) Draw(at image.Point, scr screen.Screen, win screen.Window) {
 			}
 			drawLine(t, l, l.buf.RGBA())
 		}
-		if l.buf == nil {
-			continue
+		var dx int
+		if l.buf != nil && l.buf.Bounds().Dx() <= textWidth {
+			dx = l.buf.Bounds().Dx()
+			win.Upload(image.Pt(x, y), l.buf, l.buf.Bounds())
 		}
-
-		if l.buf.Bounds().Dx() > textWidth {
-			// The line doesn't fit the width, don't draw it.
-			continue
-		}
-
-		win.Upload(image.Pt(x0, y), l.buf, l.buf.Bounds())
-		if dx := l.buf.Bounds().Dx(); dx < textWidth {
-			bg := t.setter.opts.DefaultStyle.BG
+		if dx < textWidth {
+			lineBG := bg
 			if len(l.spans) > 0 {
-				bg = l.spans[len(l.spans)-1].BG
+				lineBG = l.spans[len(l.spans)-1].BG
 			}
-			win.Fill(image.Rect(x0+dx, y, b.Max.X-pad, y1), bg, draw.Src)
+			win.Fill(image.Rect(x+dx, y, x1-pad, y1), lineBG, draw.Src)
 		}
 	}
+	if ynext < y1 {
+		win.Fill(image.Rect(x0+pad, ynext, x1-pad, y1), bg, draw.Src)
+	}
+	win.Fill(image.Rect(x0, y0, x1, y0+pad), bg, draw.Src)         // top
+	win.Fill(image.Rect(x0, y1-pad, x1, y1), bg, draw.Src)         // bottom
+	win.Fill(image.Rect(x0, y0+pad, x0+pad, y1-pad), bg, draw.Src) // left
+	win.Fill(image.Rect(x1-pad, y0+pad, x1, y1-pad), bg, draw.Src) // right
 }
 
 func drawLine(t *Text, l *line, img draw.Image) {

--- a/ui/text/text_test.go
+++ b/ui/text/text_test.go
@@ -145,7 +145,7 @@ func TestAddVerticalMetrics(t *testing.T) {
 	}
 	opts := Options{
 		DefaultStyle: medium,
-		Size:         image.Pt(5, 5),
+		Size:         image.Pt(5, 100000),
 	}
 	s := NewSetter(opts)
 

--- a/ui/text/text_test.go
+++ b/ui/text/text_test.go
@@ -16,7 +16,7 @@ import (
 func TestAdd(t *testing.T) {
 	opts := Options{
 		DefaultStyle: Style{Face: &unitFace{}},
-		Bounds:       image.Rect(0, 0, 5, 5),
+		Size:         image.Pt(5, 5),
 		TabWidth:     2,
 	}
 
@@ -87,7 +87,7 @@ func TestAdd(t *testing.T) {
 					' ': fixed.I(2),
 					'a': fixed.I(1),
 				}),
-				Bounds:   image.Rect(0, 0, 5, 5),
+				Size:     image.Pt(5, 5),
 				TabWidth: 1,
 			},
 			// Would tab to 1→2, but that is less than 2, so go ahead to 3.
@@ -100,7 +100,7 @@ func TestAdd(t *testing.T) {
 				DefaultStyle: advStyle(map[rune]fixed.Int26_6{
 					unicode.ReplacementChar: fixed.I(1),
 				}),
-				Bounds: image.Rect(0, 0, 5, 5),
+				Size: image.Pt(5, 5),
 			},
 			// Would tab to 1→2, but that is less than 2, so go ahead to 3.
 			adds: []string{"1234567890"},
@@ -145,7 +145,7 @@ func TestAddVerticalMetrics(t *testing.T) {
 	}
 	opts := Options{
 		DefaultStyle: medium,
-		Bounds:       image.Rect(0, 0, 5, 5),
+		Size:         image.Pt(5, 5),
 	}
 	s := NewSetter(opts)
 
@@ -179,14 +179,14 @@ func TestAddVerticalMetrics(t *testing.T) {
 func TestReset(t *testing.T) {
 	s := NewSetter(Options{
 		DefaultStyle: Style{Face: &unitFace{}},
-		Bounds:       image.Rect(0, 0, 5, 5),
+		Size:         image.Pt(5, 5),
 	})
 
 	s.Add([]byte("1234567890abcde"))
 
 	s.Reset(Options{
 		DefaultStyle: Style{Face: &unitFace{}},
-		Bounds:       image.Rect(0, 0, 10, 5),
+		Size:         image.Pt(10, 5),
 	})
 
 	s.Add([]byte("1234567890abcde"))
@@ -216,7 +216,7 @@ func TestTextIndex(t *testing.T) {
 				},
 				height: fixed.I(10),
 			}},
-		Bounds:   image.Rect(0, 0, 50, 50),
+		Size:     image.Pt(50, 50),
 		Padding:  10,
 		TabWidth: 1,
 	})


### PR DESCRIPTION
 1. set text based only on the box size, not it's minimum point, which is irrelevant and required lots of needless resetting when sliding text boxes around.
 2. don't double-fill, just fill padding separately.
 3. support non-zero-width newlines — found in some TTF fonts, apparently.
 4. fix end-of-line tabs — they were causing lines to appear too wide to draw.
 5. other minor tweaks.