### PR TITLE
editor: don't log harmless "send after close" errors.

### DIFF
--- a/editor/server.go
+++ b/editor/server.go
@@ -286,7 +286,9 @@ func (s *Server) changes(w http.ResponseWriter, req *http.Request) {
 		case cls := <-changes:
 			for _, cl := range cls {
 				if err := conn.Send(cl); err != nil {
-					log.Printf("Error sending to websocket: %v", err)
+					if err != websocket.ErrCloseSent {
+						log.Printf("Error sending to websocket: %v", err)
+					}
 					return
 				}
 			}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -33,6 +33,9 @@ const (
 	HandshakeTimeout = 5 * time.Second
 )
 
+// ErrCloseSent is returned by Send if sending to a connection that is closing.
+var ErrCloseSent = websocket.ErrCloseSent
+
 // A HandshakeError is returned if Dial fails the handshake.
 type HandshakeError struct {
 	// Status is the string representation of the HTTP response status code.


### PR DESCRIPTION
There is no way to prevent these errors. They occur when the remote peer closes the connection while a send is in progress. It's not log-worthy, it just means that the watcher is finished.