### PR TITLE
editor/view,ui: return errors preforming edits on a View.

### DIFF
--- a/ui/column.go
+++ b/ui/column.go
@@ -275,7 +275,7 @@ func newColumnTag(w *window) (*columnTag, error) {
 	if err != nil {
 		return nil, err
 	}
-	text.view.Do(nil, edit.Change(edit.All, columnTagText+" "), edit.Set(edit.End, '.'))
+	text.view.DoAsync(edit.Change(edit.All, columnTagText+" "), edit.Set(edit.End, '.'))
 	return &columnTag{text: text}, nil
 }
 

--- a/ui/edit_test.go
+++ b/ui/edit_test.go
@@ -832,8 +832,17 @@ func (h *testHandler) where(p image.Point) int64 {
 	return s[0]
 }
 
-func (h *testHandler) do(res chan<- []editor.EditResult, eds ...edit.Edit) {
+func (h *testHandler) doSync(eds ...edit.Edit) ([]editor.EditResult, error) {
 	h.col = -1
+	return h.do(eds...)
+}
+
+func (h *testHandler) doAsync(eds ...edit.Edit) {
+	h.col = -1
+	h.do(eds...)
+}
+
+func (h *testHandler) do(eds ...edit.Edit) ([]editor.EditResult, error) {
 	print := bytes.NewBuffer(nil)
 	var results []editor.EditResult
 	for _, e := range eds {
@@ -849,7 +858,5 @@ func (h *testHandler) do(res chan<- []editor.EditResult, eds ...edit.Edit) {
 		results = append(results, r)
 		h.seq++
 	}
-	if res != nil {
-		go func() { res <- results }()
-	}
+	return results, nil
 }

--- a/ui/window.go
+++ b/ui/window.go
@@ -536,6 +536,6 @@ func (w *window) output(str string) *sheet {
 		out.setTagFileName(outSheetName)
 		w.refocus()
 	}
-	out.body.do(nil, edit.Append(edit.End, str))
+	out.body.doAsync(edit.Append(edit.End, str))
 	return out
 }

--- a/ui/window_test.go
+++ b/ui/window_test.go
@@ -660,6 +660,7 @@ func Test_WindowOutput_NewOutputSheet(t *testing.T) {
 		t.Errorf("got %d sheets, want %d", len(newSheets), len(sheets)+1)
 	}
 }
+
 func Test_WindowOutput(t *testing.T) {
 	s, w := makeTestUI()
 	defer s.close()
@@ -701,11 +702,13 @@ func TestExec(t *testing.T) {
 	defer s.close()
 
 	sheet0 := w.columns[0].frames[1].(*sheet)
-	res := make(chan []editor.EditResult)
 	const cmdOutput = "\n" // echo with no args prints a \n.
-	sheet0.body.do(res, edit.Change(edit.End, "echo"))
-	if r := (<-res)[0]; r.Error != "" {
-		t.Fatalf("r.Error=%q", r.Error)
+	res, err := sheet0.body.doSync(edit.Change(edit.End, "echo"))
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if res[0].Error != "" {
+		t.Fatalf("r.Error=%q", res[0].Error)
 	}
 
 	// Create an output sheet so that we can read its upcoming changes.


### PR DESCRIPTION
We were returning errors from individual edits, but if the entire HTTP request failed, no error was returned, and the response channel was never notified. This caused any such error to deadlock waiting for a response that would never be sent. Now, the interface is changed to hide the underlying channel and simply return the response or an error instead.

This change also makes the ui code more explicit about whether it's doing a synchronous or asynchornous request. This is important, because we want to avoid blocking the window's event goroutine on synchronous requests, which we currently do in a few places (see #295).

Fixes #293.