### PR TITLE
edit: add ErrNoCommand

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -207,6 +207,19 @@ type Diff struct {
 	Text rope.Rope
 }
 
+// NoCommandError is returned when there was no command to execute.
+type NoCommandError struct {
+	// At contains the evaluation of the address preceding the missing command.
+	// An empty address is dot, so an empty edit results in a NoCommandError.
+	// At is set to the value of dot.
+	At [2]int64
+}
+
+// Error returns the error string "no command".
+func (e NoCommandError) Error() string {
+	return "no command"
+}
+
 // TextLen is the length of Text; 0 if Text is nil.
 func (d Diff) TextLen() int64 {
 	if d.Text == nil {
@@ -323,7 +336,7 @@ func edit(dot [2]int64, t string, print io.Writer, ro rope.Rope) (Diffs, string,
 	default:
 		return nil, "", errors.New("bad command " + string([]rune{r}))
 	case eof, '\n':
-		return nil, "", errors.New("no command")
+		return nil, "", NoCommandError{At: a}
 	case 'a', 'c', 'd', 'i':
 		return change(a, t, r, ro)
 	case 'm':

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -549,8 +549,9 @@ func TestEdit(t *testing.T) {
 			cases: []testCase{
 				{edit: "100", err: "address out of range"},
 				{edit: "a/hi/ N", err: "expected end-of-input"},
-				{edit: "", err: "no command"},
+				{edit: "", err: "no command", newdot: []int64{0, 0}},
 				{edit: "N", err: "bad command N"},
+				{edit: "/l+/", err: "no command", newdot: []int64{2, 4}},
 			},
 		},
 		{
@@ -956,10 +957,11 @@ type test struct {
 }
 
 type testCase struct {
-	edit  string
-	want  string
-	print string // regex
-	err   string // regex
+	edit   string
+	newdot []int64
+	want   string
+	print  string // regex
+	err    string // regex
 }
 
 func runAddrTest(t *testing.T, test test) {
@@ -1026,6 +1028,15 @@ func runEditTest(t *testing.T, test test) {
 			if !match(c.print, print.String()) {
 				t.Errorf("(%q).Edit(%q) print=%q, want matthing %q",
 					test.str, c.edit, print.String(), c.print)
+			}
+			if c.newdot != nil {
+				if ae, ok := err.(NoCommandError); !ok {
+					t.Errorf("(%q).Edit(%q) err=%T, want NoCommandError",
+						test.str, c.edit, err)
+				} else if ae.At[0] != c.newdot[0] || ae.At[1] != c.newdot[1] {
+					t.Errorf("(%q).Edit(%q) dot=%v, want %v",
+						test.str, c.edit, ae.At, c.newdot)
+				}
 			}
 		}
 	}

--- a/gok.sh
+++ b/gok.sh
@@ -28,6 +28,7 @@ gocyclo -over 15 .\
 	| grep -v 'main Main text/main.go'\
 	| grep -v 'main Main ui/main.go'\
 	| grep -v 'ui execCmd ui/cmd.go'\
+	| grep -v 'edit runEditTest edit/edit_test.go'\
 	> $o 2>&1
 e=$(mktemp tmp.XXXXXXXXXX)
 touch $e


### PR DESCRIPTION
Fixes #22 

I changed the name to ErrNoCommand. I think this is the standard naming convention.
There is an example in ktye/ui/cmd/sam I will update soon.